### PR TITLE
Update Grafana Agent Operator version

### DIFF
--- a/grafana-agent.yaml
+++ b/grafana-agent.yaml
@@ -24,81 +24,32 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: GrafanaAgent defines a Grafana Agent deployment.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           spec:
-            description: Spec holds the specification of the desired behavior for
-              the Grafana Agent cluster.
             properties:
               affinity:
-                description: Affinity, if specified, controls pod scheduling constraints.
                 properties:
                   nodeAffinity:
-                    description: Describes node affinity scheduling rules for the
-                      pod.
                     properties:
                       preferredDuringSchedulingIgnoredDuringExecution:
-                        description: The scheduler will prefer to schedule pods to
-                          nodes that satisfy the affinity expressions specified by
-                          this field, but it may choose a node that violates one or
-                          more of the expressions. The node that is most preferred
-                          is the one with the greatest sum of weights, i.e. for each
-                          node that meets all of the scheduling requirements (resource
-                          request, requiredDuringScheduling affinity expressions,
-                          etc.), compute a sum by iterating through the elements of
-                          this field and adding "weight" to the sum if the node matches
-                          the corresponding matchExpressions; the node(s) with the
-                          highest sum are the most preferred.
                         items:
-                          description: An empty preferred scheduling term matches
-                            all objects with implicit weight 0 (i.e. it's a no-op).
-                            A null preferred scheduling term matches no objects (i.e.
-                            is also a no-op).
                           properties:
                             preference:
-                              description: A node selector term, associated with the
-                                corresponding weight.
                               properties:
                                 matchExpressions:
-                                  description: A list of node selector requirements
-                                    by node's labels.
                                   items:
-                                    description: A node selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
                                     properties:
                                       key:
-                                        description: The label key that the selector
-                                          applies to.
                                         type: string
                                       operator:
-                                        description: Represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists, DoesNotExist. Gt, and
-                                          Lt.
                                         type: string
                                       values:
-                                        description: An array of string values. If
-                                          the operator is In or NotIn, the values
-                                          array must be non-empty. If the operator
-                                          is Exists or DoesNotExist, the values array
-                                          must be empty. If the operator is Gt or
-                                          Lt, the values array must have a single
-                                          element, which will be interpreted as an
-                                          integer. This array is replaced during a
-                                          strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -108,33 +59,13 @@ spec:
                                     type: object
                                   type: array
                                 matchFields:
-                                  description: A list of node selector requirements
-                                    by node's fields.
                                   items:
-                                    description: A node selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
                                     properties:
                                       key:
-                                        description: The label key that the selector
-                                          applies to.
                                         type: string
                                       operator:
-                                        description: Represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists, DoesNotExist. Gt, and
-                                          Lt.
                                         type: string
                                       values:
-                                        description: An array of string values. If
-                                          the operator is In or NotIn, the values
-                                          array must be non-empty. If the operator
-                                          is Exists or DoesNotExist, the values array
-                                          must be empty. If the operator is Gt or
-                                          Lt, the values array must have a single
-                                          element, which will be interpreted as an
-                                          integer. This array is replaced during a
-                                          strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -146,8 +77,6 @@ spec:
                               type: object
                               x-kubernetes-map-type: atomic
                             weight:
-                              description: Weight associated with matching the corresponding
-                                nodeSelectorTerm, in the range 1-100.
                               format: int32
                               type: integer
                           required:
@@ -156,50 +85,18 @@ spec:
                           type: object
                         type: array
                       requiredDuringSchedulingIgnoredDuringExecution:
-                        description: If the affinity requirements specified by this
-                          field are not met at scheduling time, the pod will not be
-                          scheduled onto the node. If the affinity requirements specified
-                          by this field cease to be met at some point during pod execution
-                          (e.g. due to an update), the system may or may not try to
-                          eventually evict the pod from its node.
                         properties:
                           nodeSelectorTerms:
-                            description: Required. A list of node selector terms.
-                              The terms are ORed.
                             items:
-                              description: A null or empty node selector term matches
-                                no objects. The requirements of them are ANDed. The
-                                TopologySelectorTerm type implements a subset of the
-                                NodeSelectorTerm.
                               properties:
                                 matchExpressions:
-                                  description: A list of node selector requirements
-                                    by node's labels.
                                   items:
-                                    description: A node selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
                                     properties:
                                       key:
-                                        description: The label key that the selector
-                                          applies to.
                                         type: string
                                       operator:
-                                        description: Represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists, DoesNotExist. Gt, and
-                                          Lt.
                                         type: string
                                       values:
-                                        description: An array of string values. If
-                                          the operator is In or NotIn, the values
-                                          array must be non-empty. If the operator
-                                          is Exists or DoesNotExist, the values array
-                                          must be empty. If the operator is Gt or
-                                          Lt, the values array must have a single
-                                          element, which will be interpreted as an
-                                          integer. This array is replaced during a
-                                          strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -209,33 +106,13 @@ spec:
                                     type: object
                                   type: array
                                 matchFields:
-                                  description: A list of node selector requirements
-                                    by node's fields.
                                   items:
-                                    description: A node selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
                                     properties:
                                       key:
-                                        description: The label key that the selector
-                                          applies to.
                                         type: string
                                       operator:
-                                        description: Represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists, DoesNotExist. Gt, and
-                                          Lt.
                                         type: string
                                       values:
-                                        description: An array of string values. If
-                                          the operator is In or NotIn, the values
-                                          array must be non-empty. If the operator
-                                          is Exists or DoesNotExist, the values array
-                                          must be empty. If the operator is Gt or
-                                          Lt, the values array must have a single
-                                          element, which will be interpreted as an
-                                          integer. This array is replaced during a
-                                          strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -253,61 +130,22 @@ spec:
                         x-kubernetes-map-type: atomic
                     type: object
                   podAffinity:
-                    description: Describes pod affinity scheduling rules (e.g. co-locate
-                      this pod in the same node, zone, etc. as some other pod(s)).
                     properties:
                       preferredDuringSchedulingIgnoredDuringExecution:
-                        description: The scheduler will prefer to schedule pods to
-                          nodes that satisfy the affinity expressions specified by
-                          this field, but it may choose a node that violates one or
-                          more of the expressions. The node that is most preferred
-                          is the one with the greatest sum of weights, i.e. for each
-                          node that meets all of the scheduling requirements (resource
-                          request, requiredDuringScheduling affinity expressions,
-                          etc.), compute a sum by iterating through the elements of
-                          this field and adding "weight" to the sum if the node has
-                          pods which matches the corresponding podAffinityTerm; the
-                          node(s) with the highest sum are the most preferred.
                         items:
-                          description: The weights of all of the matched WeightedPodAffinityTerm
-                            fields are added per-node to find the most preferred node(s)
                           properties:
                             podAffinityTerm:
-                              description: Required. A pod affinity term, associated
-                                with the corresponding weight.
                               properties:
                                 labelSelector:
-                                  description: A label query over a set of resources,
-                                    in this case pods.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
                                       items:
-                                        description: A label selector requirement
-                                          is a selector that contains values, a key,
-                                          and an operator that relates the key and
-                                          values.
                                         properties:
                                           key:
-                                            description: key is the label key that
-                                              the selector applies to.
                                             type: string
                                           operator:
-                                            description: operator represents a key's
-                                              relationship to a set of values. Valid
-                                              operators are In, NotIn, Exists and
-                                              DoesNotExist.
                                             type: string
                                           values:
-                                            description: values is an array of string
-                                              values. If the operator is In or NotIn,
-                                              the values array must be non-empty.
-                                              If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This
-                                              array is replaced during a strategic
-                                              merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -319,52 +157,19 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: matchLabels is a map of {key,value}
-                                        pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions,
-                                        whose key field is "key", the operator is
-                                        "In", and the values array contains only "value".
-                                        The requirements are ANDed.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 namespaceSelector:
-                                  description: A label query over the set of namespaces
-                                    that the term applies to. The term is applied
-                                    to the union of the namespaces selected by this
-                                    field and the ones listed in the namespaces field.
-                                    null selector and null or empty namespaces list
-                                    means "this pod's namespace". An empty selector
-                                    ({}) matches all namespaces.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
                                       items:
-                                        description: A label selector requirement
-                                          is a selector that contains values, a key,
-                                          and an operator that relates the key and
-                                          values.
                                         properties:
                                           key:
-                                            description: key is the label key that
-                                              the selector applies to.
                                             type: string
                                           operator:
-                                            description: operator represents a key's
-                                              relationship to a set of values. Valid
-                                              operators are In, NotIn, Exists and
-                                              DoesNotExist.
                                             type: string
                                           values:
-                                            description: values is an array of string
-                                              values. If the operator is In or NotIn,
-                                              the values array must be non-empty.
-                                              If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This
-                                              array is replaced during a strategic
-                                              merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -376,40 +181,19 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: matchLabels is a map of {key,value}
-                                        pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions,
-                                        whose key field is "key", the operator is
-                                        "In", and the values array contains only "value".
-                                        The requirements are ANDed.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 namespaces:
-                                  description: namespaces specifies a static list
-                                    of namespace names that the term applies to. The
-                                    term is applied to the union of the namespaces
-                                    listed in this field and the ones selected by
-                                    namespaceSelector. null or empty namespaces list
-                                    and null namespaceSelector means "this pod's namespace".
                                   items:
                                     type: string
                                   type: array
                                 topologyKey:
-                                  description: This pod should be co-located (affinity)
-                                    or not co-located (anti-affinity) with the pods
-                                    matching the labelSelector in the specified namespaces,
-                                    where co-located is defined as running on a node
-                                    whose value of the label with key topologyKey
-                                    matches that of any node on which any of the selected
-                                    pods is running. Empty topologyKey is not allowed.
                                   type: string
                               required:
                               - topologyKey
                               type: object
                             weight:
-                              description: weight associated with matching the corresponding
-                                podAffinityTerm, in the range 1-100.
                               format: int32
                               type: integer
                           required:
@@ -418,52 +202,18 @@ spec:
                           type: object
                         type: array
                       requiredDuringSchedulingIgnoredDuringExecution:
-                        description: If the affinity requirements specified by this
-                          field are not met at scheduling time, the pod will not be
-                          scheduled onto the node. If the affinity requirements specified
-                          by this field cease to be met at some point during pod execution
-                          (e.g. due to a pod label update), the system may or may
-                          not try to eventually evict the pod from its node. When
-                          there are multiple elements, the lists of nodes corresponding
-                          to each podAffinityTerm are intersected, i.e. all terms
-                          must be satisfied.
                         items:
-                          description: Defines a set of pods (namely those matching
-                            the labelSelector relative to the given namespace(s))
-                            that this pod should be co-located (affinity) or not co-located
-                            (anti-affinity) with, where co-located is defined as running
-                            on a node whose value of the label with key <topologyKey>
-                            matches that of any node on which a pod of the set of
-                            pods is running
                           properties:
                             labelSelector:
-                              description: A label query over a set of resources,
-                                in this case pods.
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label
-                                    selector requirements. The requirements are ANDed.
                                   items:
-                                    description: A label selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the
-                                          selector applies to.
                                         type: string
                                       operator:
-                                        description: operator represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: values is an array of string
-                                          values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the
-                                          operator is Exists or DoesNotExist, the
-                                          values array must be empty. This array is
-                                          replaced during a strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -475,47 +225,19 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: matchLabels is a map of {key,value}
-                                    pairs. A single {key,value} in the matchLabels
-                                    map is equivalent to an element of matchExpressions,
-                                    whose key field is "key", the operator is "In",
-                                    and the values array contains only "value". The
-                                    requirements are ANDed.
                                   type: object
                               type: object
                               x-kubernetes-map-type: atomic
                             namespaceSelector:
-                              description: A label query over the set of namespaces
-                                that the term applies to. The term is applied to the
-                                union of the namespaces selected by this field and
-                                the ones listed in the namespaces field. null selector
-                                and null or empty namespaces list means "this pod's
-                                namespace". An empty selector ({}) matches all namespaces.
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label
-                                    selector requirements. The requirements are ANDed.
                                   items:
-                                    description: A label selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the
-                                          selector applies to.
                                         type: string
                                       operator:
-                                        description: operator represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: values is an array of string
-                                          values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the
-                                          operator is Exists or DoesNotExist, the
-                                          values array must be empty. This array is
-                                          replaced during a strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -527,33 +249,14 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: matchLabels is a map of {key,value}
-                                    pairs. A single {key,value} in the matchLabels
-                                    map is equivalent to an element of matchExpressions,
-                                    whose key field is "key", the operator is "In",
-                                    and the values array contains only "value". The
-                                    requirements are ANDed.
                                   type: object
                               type: object
                               x-kubernetes-map-type: atomic
                             namespaces:
-                              description: namespaces specifies a static list of namespace
-                                names that the term applies to. The term is applied
-                                to the union of the namespaces listed in this field
-                                and the ones selected by namespaceSelector. null or
-                                empty namespaces list and null namespaceSelector means
-                                "this pod's namespace".
                               items:
                                 type: string
                               type: array
                             topologyKey:
-                              description: This pod should be co-located (affinity)
-                                or not co-located (anti-affinity) with the pods matching
-                                the labelSelector in the specified namespaces, where
-                                co-located is defined as running on a node whose value
-                                of the label with key topologyKey matches that of
-                                any node on which any of the selected pods is running.
-                                Empty topologyKey is not allowed.
                               type: string
                           required:
                           - topologyKey
@@ -561,62 +264,22 @@ spec:
                         type: array
                     type: object
                   podAntiAffinity:
-                    description: Describes pod anti-affinity scheduling rules (e.g.
-                      avoid putting this pod in the same node, zone, etc. as some
-                      other pod(s)).
                     properties:
                       preferredDuringSchedulingIgnoredDuringExecution:
-                        description: The scheduler will prefer to schedule pods to
-                          nodes that satisfy the anti-affinity expressions specified
-                          by this field, but it may choose a node that violates one
-                          or more of the expressions. The node that is most preferred
-                          is the one with the greatest sum of weights, i.e. for each
-                          node that meets all of the scheduling requirements (resource
-                          request, requiredDuringScheduling anti-affinity expressions,
-                          etc.), compute a sum by iterating through the elements of
-                          this field and adding "weight" to the sum if the node has
-                          pods which matches the corresponding podAffinityTerm; the
-                          node(s) with the highest sum are the most preferred.
                         items:
-                          description: The weights of all of the matched WeightedPodAffinityTerm
-                            fields are added per-node to find the most preferred node(s)
                           properties:
                             podAffinityTerm:
-                              description: Required. A pod affinity term, associated
-                                with the corresponding weight.
                               properties:
                                 labelSelector:
-                                  description: A label query over a set of resources,
-                                    in this case pods.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
                                       items:
-                                        description: A label selector requirement
-                                          is a selector that contains values, a key,
-                                          and an operator that relates the key and
-                                          values.
                                         properties:
                                           key:
-                                            description: key is the label key that
-                                              the selector applies to.
                                             type: string
                                           operator:
-                                            description: operator represents a key's
-                                              relationship to a set of values. Valid
-                                              operators are In, NotIn, Exists and
-                                              DoesNotExist.
                                             type: string
                                           values:
-                                            description: values is an array of string
-                                              values. If the operator is In or NotIn,
-                                              the values array must be non-empty.
-                                              If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This
-                                              array is replaced during a strategic
-                                              merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -628,52 +291,19 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: matchLabels is a map of {key,value}
-                                        pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions,
-                                        whose key field is "key", the operator is
-                                        "In", and the values array contains only "value".
-                                        The requirements are ANDed.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 namespaceSelector:
-                                  description: A label query over the set of namespaces
-                                    that the term applies to. The term is applied
-                                    to the union of the namespaces selected by this
-                                    field and the ones listed in the namespaces field.
-                                    null selector and null or empty namespaces list
-                                    means "this pod's namespace". An empty selector
-                                    ({}) matches all namespaces.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
                                       items:
-                                        description: A label selector requirement
-                                          is a selector that contains values, a key,
-                                          and an operator that relates the key and
-                                          values.
                                         properties:
                                           key:
-                                            description: key is the label key that
-                                              the selector applies to.
                                             type: string
                                           operator:
-                                            description: operator represents a key's
-                                              relationship to a set of values. Valid
-                                              operators are In, NotIn, Exists and
-                                              DoesNotExist.
                                             type: string
                                           values:
-                                            description: values is an array of string
-                                              values. If the operator is In or NotIn,
-                                              the values array must be non-empty.
-                                              If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This
-                                              array is replaced during a strategic
-                                              merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -685,40 +315,19 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: matchLabels is a map of {key,value}
-                                        pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions,
-                                        whose key field is "key", the operator is
-                                        "In", and the values array contains only "value".
-                                        The requirements are ANDed.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 namespaces:
-                                  description: namespaces specifies a static list
-                                    of namespace names that the term applies to. The
-                                    term is applied to the union of the namespaces
-                                    listed in this field and the ones selected by
-                                    namespaceSelector. null or empty namespaces list
-                                    and null namespaceSelector means "this pod's namespace".
                                   items:
                                     type: string
                                   type: array
                                 topologyKey:
-                                  description: This pod should be co-located (affinity)
-                                    or not co-located (anti-affinity) with the pods
-                                    matching the labelSelector in the specified namespaces,
-                                    where co-located is defined as running on a node
-                                    whose value of the label with key topologyKey
-                                    matches that of any node on which any of the selected
-                                    pods is running. Empty topologyKey is not allowed.
                                   type: string
                               required:
                               - topologyKey
                               type: object
                             weight:
-                              description: weight associated with matching the corresponding
-                                podAffinityTerm, in the range 1-100.
                               format: int32
                               type: integer
                           required:
@@ -727,52 +336,18 @@ spec:
                           type: object
                         type: array
                       requiredDuringSchedulingIgnoredDuringExecution:
-                        description: If the anti-affinity requirements specified by
-                          this field are not met at scheduling time, the pod will
-                          not be scheduled onto the node. If the anti-affinity requirements
-                          specified by this field cease to be met at some point during
-                          pod execution (e.g. due to a pod label update), the system
-                          may or may not try to eventually evict the pod from its
-                          node. When there are multiple elements, the lists of nodes
-                          corresponding to each podAffinityTerm are intersected, i.e.
-                          all terms must be satisfied.
                         items:
-                          description: Defines a set of pods (namely those matching
-                            the labelSelector relative to the given namespace(s))
-                            that this pod should be co-located (affinity) or not co-located
-                            (anti-affinity) with, where co-located is defined as running
-                            on a node whose value of the label with key <topologyKey>
-                            matches that of any node on which a pod of the set of
-                            pods is running
                           properties:
                             labelSelector:
-                              description: A label query over a set of resources,
-                                in this case pods.
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label
-                                    selector requirements. The requirements are ANDed.
                                   items:
-                                    description: A label selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the
-                                          selector applies to.
                                         type: string
                                       operator:
-                                        description: operator represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: values is an array of string
-                                          values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the
-                                          operator is Exists or DoesNotExist, the
-                                          values array must be empty. This array is
-                                          replaced during a strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -784,47 +359,19 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: matchLabels is a map of {key,value}
-                                    pairs. A single {key,value} in the matchLabels
-                                    map is equivalent to an element of matchExpressions,
-                                    whose key field is "key", the operator is "In",
-                                    and the values array contains only "value". The
-                                    requirements are ANDed.
                                   type: object
                               type: object
                               x-kubernetes-map-type: atomic
                             namespaceSelector:
-                              description: A label query over the set of namespaces
-                                that the term applies to. The term is applied to the
-                                union of the namespaces selected by this field and
-                                the ones listed in the namespaces field. null selector
-                                and null or empty namespaces list means "this pod's
-                                namespace". An empty selector ({}) matches all namespaces.
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label
-                                    selector requirements. The requirements are ANDed.
                                   items:
-                                    description: A label selector requirement is a
-                                      selector that contains values, a key, and an
-                                      operator that relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the
-                                          selector applies to.
                                         type: string
                                       operator:
-                                        description: operator represents a key's relationship
-                                          to a set of values. Valid operators are
-                                          In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: values is an array of string
-                                          values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the
-                                          operator is Exists or DoesNotExist, the
-                                          values array must be empty. This array is
-                                          replaced during a strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -836,33 +383,14 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: matchLabels is a map of {key,value}
-                                    pairs. A single {key,value} in the matchLabels
-                                    map is equivalent to an element of matchExpressions,
-                                    whose key field is "key", the operator is "In",
-                                    and the values array contains only "value". The
-                                    requirements are ANDed.
                                   type: object
                               type: object
                               x-kubernetes-map-type: atomic
                             namespaces:
-                              description: namespaces specifies a static list of namespace
-                                names that the term applies to. The term is applied
-                                to the union of the namespaces listed in this field
-                                and the ones selected by namespaceSelector. null or
-                                empty namespaces list and null namespaceSelector means
-                                "this pod's namespace".
                               items:
                                 type: string
                               type: array
                             topologyKey:
-                              description: This pod should be co-located (affinity)
-                                or not co-located (anti-affinity) with the pods matching
-                                the labelSelector in the specified namespaces, where
-                                co-located is defined as running on a node whose value
-                                of the label with key topologyKey matches that of
-                                any node on which any of the selected pods is running.
-                                Empty topologyKey is not allowed.
                               type: string
                           required:
                           - topologyKey
@@ -871,83 +399,47 @@ spec:
                     type: object
                 type: object
               apiServer:
-                description: APIServerConfig lets you specify a host and auth methods
-                  to access the Kubernetes API server. If left empty, the Agent assumes
-                  that it is running inside of the cluster and will discover API servers
-                  automatically and use the pod's CA certificate and bearer token
-                  file at /var/run/secrets/kubernetes.io/serviceaccount.
                 properties:
                   authorization:
-                    description: Authorization section for accessing apiserver
                     properties:
                       credentials:
-                        description: The secret's key that contains the credentials
-                          of the request
                         properties:
                           key:
-                            description: The key of the secret to select from.  Must
-                              be a valid secret key.
                             type: string
                           name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                           optional:
-                            description: Specify whether the Secret or its key must
-                              be defined
                             type: boolean
                         required:
                         - key
                         type: object
                         x-kubernetes-map-type: atomic
                       credentialsFile:
-                        description: File to read a secret from, mutually exclusive
-                          with Credentials (from SafeAuthorization)
                         type: string
                       type:
-                        description: Set the authentication type. Defaults to Bearer,
-                          Basic will cause an error
                         type: string
                     type: object
                   basicAuth:
-                    description: BasicAuth allow an endpoint to authenticate over
-                      basic authentication
                     properties:
                       password:
-                        description: The secret in the service monitor namespace that
-                          contains the password for authentication.
                         properties:
                           key:
-                            description: The key of the secret to select from.  Must
-                              be a valid secret key.
                             type: string
                           name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                           optional:
-                            description: Specify whether the Secret or its key must
-                              be defined
                             type: boolean
                         required:
                         - key
                         type: object
                         x-kubernetes-map-type: atomic
                       username:
-                        description: The secret in the service monitor namespace that
-                          contains the username for authentication.
                         properties:
                           key:
-                            description: The key of the secret to select from.  Must
-                              be a valid secret key.
                             type: string
                           name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                           optional:
-                            description: Specify whether the Secret or its key must
-                              be defined
                             type: boolean
                         required:
                         - key
@@ -955,57 +447,34 @@ spec:
                         x-kubernetes-map-type: atomic
                     type: object
                   bearerToken:
-                    description: Bearer token for accessing apiserver.
                     type: string
                   bearerTokenFile:
-                    description: File to read bearer token for accessing apiserver.
                     type: string
                   host:
-                    description: Host of apiserver. A valid string consisting of a
-                      hostname or IP followed by an optional port number
                     type: string
                   tlsConfig:
-                    description: TLS Config to use for accessing apiserver.
                     properties:
                       ca:
-                        description: Certificate authority used when verifying server
-                          certificates.
                         properties:
                           configMap:
-                            description: ConfigMap containing data to use for the
-                              targets.
                             properties:
                               key:
-                                description: The key to select.
                                 type: string
                               name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion, kind,
-                                  uid?'
                                 type: string
                               optional:
-                                description: Specify whether the ConfigMap or its
-                                  key must be defined
                                 type: boolean
                             required:
                             - key
                             type: object
                             x-kubernetes-map-type: atomic
                           secret:
-                            description: Secret containing data to use for the targets.
                             properties:
                               key:
-                                description: The key of the secret to select from.  Must
-                                  be a valid secret key.
                                 type: string
                               name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion, kind,
-                                  uid?'
                                 type: string
                               optional:
-                                description: Specify whether the Secret or its key
-                                  must be defined
                                 type: boolean
                             required:
                             - key
@@ -1013,47 +482,28 @@ spec:
                             x-kubernetes-map-type: atomic
                         type: object
                       caFile:
-                        description: Path to the CA cert in the Prometheus container
-                          to use for the targets.
                         type: string
                       cert:
-                        description: Client certificate to present when doing client-authentication.
                         properties:
                           configMap:
-                            description: ConfigMap containing data to use for the
-                              targets.
                             properties:
                               key:
-                                description: The key to select.
                                 type: string
                               name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion, kind,
-                                  uid?'
                                 type: string
                               optional:
-                                description: Specify whether the ConfigMap or its
-                                  key must be defined
                                 type: boolean
                             required:
                             - key
                             type: object
                             x-kubernetes-map-type: atomic
                           secret:
-                            description: Secret containing data to use for the targets.
                             properties:
                               key:
-                                description: The key of the secret to select from.  Must
-                                  be a valid secret key.
                                 type: string
                               name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion, kind,
-                                  uid?'
                                 type: string
                               optional:
-                                description: Specify whether the Secret or its key
-                                  must be defined
                                 type: boolean
                             required:
                             - key
@@ -1061,210 +511,102 @@ spec:
                             x-kubernetes-map-type: atomic
                         type: object
                       certFile:
-                        description: Path to the client cert file in the Prometheus
-                          container for the targets.
                         type: string
                       insecureSkipVerify:
-                        description: Disable target certificate validation.
                         type: boolean
                       keyFile:
-                        description: Path to the client key file in the Prometheus
-                          container for the targets.
                         type: string
                       keySecret:
-                        description: Secret containing the client key file for the
-                          targets.
                         properties:
                           key:
-                            description: The key of the secret to select from.  Must
-                              be a valid secret key.
                             type: string
                           name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                           optional:
-                            description: Specify whether the Secret or its key must
-                              be defined
                             type: boolean
                         required:
                         - key
                         type: object
                         x-kubernetes-map-type: atomic
                       serverName:
-                        description: Used to verify the hostname for the targets.
                         type: string
                     type: object
                 required:
                 - host
                 type: object
               configMaps:
-                description: ConfigMaps is a list of config maps in the same namespace
-                  as the GrafanaAgent object which will be mounted into each running
-                  Grafana Agent pod. The ConfigMaps are mounted into /var/lib/grafana-agent/extra-configmaps/<configmap-name>.
                 items:
                   type: string
                 type: array
               configReloaderImage:
-                description: Image, when specified, overrides the image used to run
-                  Config Reloader. Specify the image along with a tag. You still need
-                  to set the version to ensure Grafana Agent Operator knows which
-                  version of Grafana Agent is being configured.
                 type: string
               configReloaderVersion:
-                description: Version of Config Reloader to be deployed.
                 type: string
               containers:
-                description: 'Containers lets you inject additional containers or
-                  modify operator-generated containers. This can be used to add an
-                  authentication proxy to a Grafana Agent pod or to change the behavior
-                  of an operator-generated container. Containers described here modify
-                  an operator-generated container if they share the same name and
-                  if modifications are done via a strategic merge patch. The current
-                  container names are: `grafana-agent` and `config-reloader`. Overriding
-                  containers is entirely outside the scope of what the Grafana Agent
-                  team supports and by doing so, you accept that this behavior may
-                  break at any time without notice.'
                 items:
-                  description: A single application container that you want to run
-                    within a pod.
                   properties:
                     args:
-                      description: 'Arguments to the entrypoint. The container image''s
-                        CMD is used if this is not provided. Variable references $(VAR_NAME)
-                        are expanded using the container''s environment. If a variable
-                        cannot be resolved, the reference in the input string will
-                        be unchanged. Double $$ are reduced to a single $, which allows
-                        for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
-                        produce the string literal "$(VAR_NAME)". Escaped references
-                        will never be expanded, regardless of whether the variable
-                        exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                       items:
                         type: string
                       type: array
                     command:
-                      description: 'Entrypoint array. Not executed within a shell.
-                        The container image''s ENTRYPOINT is used if this is not provided.
-                        Variable references $(VAR_NAME) are expanded using the container''s
-                        environment. If a variable cannot be resolved, the reference
-                        in the input string will be unchanged. Double $$ are reduced
-                        to a single $, which allows for escaping the $(VAR_NAME) syntax:
-                        i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
-                        Escaped references will never be expanded, regardless of whether
-                        the variable exists or not. Cannot be updated. More info:
-                        https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                       items:
                         type: string
                       type: array
                     env:
-                      description: List of environment variables to set in the container.
-                        Cannot be updated.
                       items:
-                        description: EnvVar represents an environment variable present
-                          in a Container.
                         properties:
                           name:
-                            description: Name of the environment variable. Must be
-                              a C_IDENTIFIER.
                             type: string
                           value:
-                            description: 'Variable references $(VAR_NAME) are expanded
-                              using the previously defined environment variables in
-                              the container and any service environment variables.
-                              If a variable cannot be resolved, the reference in the
-                              input string will be unchanged. Double $$ are reduced
-                              to a single $, which allows for escaping the $(VAR_NAME)
-                              syntax: i.e. "$$(VAR_NAME)" will produce the string
-                              literal "$(VAR_NAME)". Escaped references will never
-                              be expanded, regardless of whether the variable exists
-                              or not. Defaults to "".'
                             type: string
                           valueFrom:
-                            description: Source for the environment variable's value.
-                              Cannot be used if value is not empty.
                             properties:
                               configMapKeyRef:
-                                description: Selects a key of a ConfigMap.
                                 properties:
                                   key:
-                                    description: The key to select.
                                     type: string
                                   name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
                                     type: string
                                   optional:
-                                    description: Specify whether the ConfigMap or
-                                      its key must be defined
                                     type: boolean
                                 required:
                                 - key
                                 type: object
                                 x-kubernetes-map-type: atomic
                               fieldRef:
-                                description: 'Selects a field of the pod: supports
-                                  metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
-                                  `metadata.annotations[''<KEY>'']`, spec.nodeName,
-                                  spec.serviceAccountName, status.hostIP, status.podIP,
-                                  status.podIPs.'
                                 properties:
                                   apiVersion:
-                                    description: Version of the schema the FieldPath
-                                      is written in terms of, defaults to "v1".
                                     type: string
                                   fieldPath:
-                                    description: Path of the field to select in the
-                                      specified API version.
                                     type: string
                                 required:
                                 - fieldPath
                                 type: object
                                 x-kubernetes-map-type: atomic
                               resourceFieldRef:
-                                description: 'Selects a resource of the container:
-                                  only resources limits and requests (limits.cpu,
-                                  limits.memory, limits.ephemeral-storage, requests.cpu,
-                                  requests.memory and requests.ephemeral-storage)
-                                  are currently supported.'
                                 properties:
                                   containerName:
-                                    description: 'Container name: required for volumes,
-                                      optional for env vars'
                                     type: string
                                   divisor:
                                     anyOf:
                                     - type: integer
                                     - type: string
-                                    description: Specifies the output format of the
-                                      exposed resources, defaults to "1"
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                   resource:
-                                    description: 'Required: resource to select'
                                     type: string
                                 required:
                                 - resource
                                 type: object
                                 x-kubernetes-map-type: atomic
                               secretKeyRef:
-                                description: Selects a key of a secret in the pod's
-                                  namespace
                                 properties:
                                   key:
-                                    description: The key of the secret to select from.  Must
-                                      be a valid secret key.
                                     type: string
                                   name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
                                     type: string
                                   optional:
-                                    description: Specify whether the Secret or its
-                                      key must be defined
                                     type: boolean
                                 required:
                                 - key
@@ -1276,111 +618,53 @@ spec:
                         type: object
                       type: array
                     envFrom:
-                      description: List of sources to populate environment variables
-                        in the container. The keys defined within a source must be
-                        a C_IDENTIFIER. All invalid keys will be reported as an event
-                        when the container is starting. When a key exists in multiple
-                        sources, the value associated with the last source will take
-                        precedence. Values defined by an Env with a duplicate key
-                        will take precedence. Cannot be updated.
                       items:
-                        description: EnvFromSource represents the source of a set
-                          of ConfigMaps
                         properties:
                           configMapRef:
-                            description: The ConfigMap to select from
                             properties:
                               name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion, kind,
-                                  uid?'
                                 type: string
                               optional:
-                                description: Specify whether the ConfigMap must be
-                                  defined
                                 type: boolean
                             type: object
                             x-kubernetes-map-type: atomic
                           prefix:
-                            description: An optional identifier to prepend to each
-                              key in the ConfigMap. Must be a C_IDENTIFIER.
                             type: string
                           secretRef:
-                            description: The Secret to select from
                             properties:
                               name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion, kind,
-                                  uid?'
                                 type: string
                               optional:
-                                description: Specify whether the Secret must be defined
                                 type: boolean
                             type: object
                             x-kubernetes-map-type: atomic
                         type: object
                       type: array
                     image:
-                      description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images
-                        This field is optional to allow higher level config management
-                        to default or override container images in workload controllers
-                        like Deployments and StatefulSets.'
                       type: string
                     imagePullPolicy:
-                      description: 'Image pull policy. One of Always, Never, IfNotPresent.
-                        Defaults to Always if :latest tag is specified, or IfNotPresent
-                        otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
                       type: string
                     lifecycle:
-                      description: Actions that the management system should take
-                        in response to container lifecycle events. Cannot be updated.
                       properties:
                         postStart:
-                          description: 'PostStart is called immediately after a container
-                            is created. If the handler fails, the container is terminated
-                            and restarted according to its restart policy. Other management
-                            of the container blocks until the hook completes. More
-                            info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                           properties:
                             exec:
-                              description: Exec specifies the action to take.
                               properties:
                                 command:
-                                  description: Command is the command line to execute
-                                    inside the container, the working directory for
-                                    the command  is root ('/') in the container's
-                                    filesystem. The command is simply exec'd, it is
-                                    not run inside a shell, so traditional shell instructions
-                                    ('|', etc) won't work. To use a shell, you need
-                                    to explicitly call out to that shell. Exit status
-                                    of 0 is treated as live/healthy and non-zero is
-                                    unhealthy.
                                   items:
                                     type: string
                                   type: array
                               type: object
                             httpGet:
-                              description: HTTPGet specifies the http request to perform.
                               properties:
                                 host:
-                                  description: Host name to connect to, defaults to
-                                    the pod IP. You probably want to set "Host" in
-                                    httpHeaders instead.
                                   type: string
                                 httpHeaders:
-                                  description: Custom headers to set in the request.
-                                    HTTP allows repeated headers.
                                   items:
-                                    description: HTTPHeader describes a custom header
-                                      to be used in HTTP probes
                                     properties:
                                       name:
-                                        description: The header field name. This will
-                                          be canonicalized upon output, so case-variant
-                                          names will be understood as the same header.
                                         type: string
                                       value:
-                                        description: The header field value
                                         type: string
                                     required:
                                     - name
@@ -1388,97 +672,49 @@ spec:
                                     type: object
                                   type: array
                                 path:
-                                  description: Path to access on the HTTP server.
                                   type: string
                                 port:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: Name or number of the port to access
-                                    on the container. Number must be in the range
-                                    1 to 65535. Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
                                 scheme:
-                                  description: Scheme to use for connecting to the
-                                    host. Defaults to HTTP.
                                   type: string
                               required:
                               - port
                               type: object
                             tcpSocket:
-                              description: Deprecated. TCPSocket is NOT supported
-                                as a LifecycleHandler and kept for the backward compatibility.
-                                There are no validation of this field and lifecycle
-                                hooks will fail in runtime when tcp handler is specified.
                               properties:
                                 host:
-                                  description: 'Optional: Host name to connect to,
-                                    defaults to the pod IP.'
                                   type: string
                                 port:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: Number or name of the port to access
-                                    on the container. Number must be in the range
-                                    1 to 65535. Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
                               required:
                               - port
                               type: object
                           type: object
                         preStop:
-                          description: 'PreStop is called immediately before a container
-                            is terminated due to an API request or management event
-                            such as liveness/startup probe failure, preemption, resource
-                            contention, etc. The handler is not called if the container
-                            crashes or exits. The Pod''s termination grace period
-                            countdown begins before the PreStop hook is executed.
-                            Regardless of the outcome of the handler, the container
-                            will eventually terminate within the Pod''s termination
-                            grace period (unless delayed by finalizers). Other management
-                            of the container blocks until the hook completes or until
-                            the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                           properties:
                             exec:
-                              description: Exec specifies the action to take.
                               properties:
                                 command:
-                                  description: Command is the command line to execute
-                                    inside the container, the working directory for
-                                    the command  is root ('/') in the container's
-                                    filesystem. The command is simply exec'd, it is
-                                    not run inside a shell, so traditional shell instructions
-                                    ('|', etc) won't work. To use a shell, you need
-                                    to explicitly call out to that shell. Exit status
-                                    of 0 is treated as live/healthy and non-zero is
-                                    unhealthy.
                                   items:
                                     type: string
                                   type: array
                               type: object
                             httpGet:
-                              description: HTTPGet specifies the http request to perform.
                               properties:
                                 host:
-                                  description: Host name to connect to, defaults to
-                                    the pod IP. You probably want to set "Host" in
-                                    httpHeaders instead.
                                   type: string
                                 httpHeaders:
-                                  description: Custom headers to set in the request.
-                                    HTTP allows repeated headers.
                                   items:
-                                    description: HTTPHeader describes a custom header
-                                      to be used in HTTP probes
                                     properties:
                                       name:
-                                        description: The header field name. This will
-                                          be canonicalized upon output, so case-variant
-                                          names will be understood as the same header.
                                         type: string
                                       value:
-                                        description: The header field value
                                         type: string
                                     required:
                                     - name
@@ -1486,40 +722,25 @@ spec:
                                     type: object
                                   type: array
                                 path:
-                                  description: Path to access on the HTTP server.
                                   type: string
                                 port:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: Name or number of the port to access
-                                    on the container. Number must be in the range
-                                    1 to 65535. Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
                                 scheme:
-                                  description: Scheme to use for connecting to the
-                                    host. Defaults to HTTP.
                                   type: string
                               required:
                               - port
                               type: object
                             tcpSocket:
-                              description: Deprecated. TCPSocket is NOT supported
-                                as a LifecycleHandler and kept for the backward compatibility.
-                                There are no validation of this field and lifecycle
-                                hooks will fail in runtime when tcp handler is specified.
                               properties:
                                 host:
-                                  description: 'Optional: Host name to connect to,
-                                    defaults to the pod IP.'
                                   type: string
                                 port:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: Number or name of the port to access
-                                    on the container. Number must be in the range
-                                    1 to 65535. Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
                               required:
                               - port
@@ -1527,71 +748,37 @@ spec:
                           type: object
                       type: object
                     livenessProbe:
-                      description: 'Periodic probe of container liveness. Container
-                        will be restarted if the probe fails. Cannot be updated. More
-                        info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                       properties:
                         exec:
-                          description: Exec specifies the action to take.
                           properties:
                             command:
-                              description: Command is the command line to execute
-                                inside the container, the working directory for the
-                                command  is root ('/') in the container's filesystem.
-                                The command is simply exec'd, it is not run inside
-                                a shell, so traditional shell instructions ('|', etc)
-                                won't work. To use a shell, you need to explicitly
-                                call out to that shell. Exit status of 0 is treated
-                                as live/healthy and non-zero is unhealthy.
                               items:
                                 type: string
                               type: array
                           type: object
                         failureThreshold:
-                          description: Minimum consecutive failures for the probe
-                            to be considered failed after having succeeded. Defaults
-                            to 3. Minimum value is 1.
                           format: int32
                           type: integer
                         grpc:
-                          description: GRPC specifies an action involving a GRPC port.
                           properties:
                             port:
-                              description: Port number of the gRPC service. Number
-                                must be in the range 1 to 65535.
                               format: int32
                               type: integer
                             service:
-                              description: "Service is the name of the service to
-                                place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                \n If this is not specified, the default behavior
-                                is defined by gRPC."
                               type: string
                           required:
                           - port
                           type: object
                         httpGet:
-                          description: HTTPGet specifies the http request to perform.
                           properties:
                             host:
-                              description: Host name to connect to, defaults to the
-                                pod IP. You probably want to set "Host" in httpHeaders
-                                instead.
                               type: string
                             httpHeaders:
-                              description: Custom headers to set in the request. HTTP
-                                allows repeated headers.
                               items:
-                                description: HTTPHeader describes a custom header
-                                  to be used in HTTP probes
                                 properties:
                                   name:
-                                    description: The header field name. This will
-                                      be canonicalized upon output, so case-variant
-                                      names will be understood as the same header.
                                     type: string
                                   value:
-                                    description: The header field value
                                     type: string
                                 required:
                                 - name
@@ -1599,126 +786,62 @@ spec:
                                 type: object
                               type: array
                             path:
-                              description: Path to access on the HTTP server.
                               type: string
                             port:
                               anyOf:
                               - type: integer
                               - type: string
-                              description: Name or number of the port to access on
-                                the container. Number must be in the range 1 to 65535.
-                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                             scheme:
-                              description: Scheme to use for connecting to the host.
-                                Defaults to HTTP.
                               type: string
                           required:
                           - port
                           type: object
                         initialDelaySeconds:
-                          description: 'Number of seconds after the container has
-                            started before liveness probes are initiated. More info:
-                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                           format: int32
                           type: integer
                         periodSeconds:
-                          description: How often (in seconds) to perform the probe.
-                            Default to 10 seconds. Minimum value is 1.
                           format: int32
                           type: integer
                         successThreshold:
-                          description: Minimum consecutive successes for the probe
-                            to be considered successful after having failed. Defaults
-                            to 1. Must be 1 for liveness and startup. Minimum value
-                            is 1.
                           format: int32
                           type: integer
                         tcpSocket:
-                          description: TCPSocket specifies an action involving a TCP
-                            port.
                           properties:
                             host:
-                              description: 'Optional: Host name to connect to, defaults
-                                to the pod IP.'
                               type: string
                             port:
                               anyOf:
                               - type: integer
                               - type: string
-                              description: Number or name of the port to access on
-                                the container. Number must be in the range 1 to 65535.
-                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                           required:
                           - port
                           type: object
                         terminationGracePeriodSeconds:
-                          description: Optional duration in seconds the pod needs
-                            to terminate gracefully upon probe failure. The grace
-                            period is the duration in seconds after the processes
-                            running in the pod are sent a termination signal and the
-                            time when the processes are forcibly halted with a kill
-                            signal. Set this value longer than the expected cleanup
-                            time for your process. If this value is nil, the pod's
-                            terminationGracePeriodSeconds will be used. Otherwise,
-                            this value overrides the value provided by the pod spec.
-                            Value must be non-negative integer. The value zero indicates
-                            stop immediately via the kill signal (no opportunity to
-                            shut down). This is a beta field and requires enabling
-                            ProbeTerminationGracePeriod feature gate. Minimum value
-                            is 1. spec.terminationGracePeriodSeconds is used if unset.
                           format: int64
                           type: integer
                         timeoutSeconds:
-                          description: 'Number of seconds after which the probe times
-                            out. Defaults to 1 second. Minimum value is 1. More info:
-                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                           format: int32
                           type: integer
                       type: object
                     name:
-                      description: Name of the container specified as a DNS_LABEL.
-                        Each container in a pod must have a unique name (DNS_LABEL).
-                        Cannot be updated.
                       type: string
                     ports:
-                      description: List of ports to expose from the container. Not
-                        specifying a port here DOES NOT prevent that port from being
-                        exposed. Any port which is listening on the default "0.0.0.0"
-                        address inside a container will be accessible from the network.
-                        Modifying this array with strategic merge patch may corrupt
-                        the data. For more information See https://github.com/kubernetes/kubernetes/issues/108255.
-                        Cannot be updated.
                       items:
-                        description: ContainerPort represents a network port in a
-                          single container.
                         properties:
                           containerPort:
-                            description: Number of port to expose on the pod's IP
-                              address. This must be a valid port number, 0 < x < 65536.
                             format: int32
                             type: integer
                           hostIP:
-                            description: What host IP to bind the external port to.
                             type: string
                           hostPort:
-                            description: Number of port to expose on the host. If
-                              specified, this must be a valid port number, 0 < x <
-                              65536. If HostNetwork is specified, this must match
-                              ContainerPort. Most containers do not need this.
                             format: int32
                             type: integer
                           name:
-                            description: If specified, this must be an IANA_SVC_NAME
-                              and unique within the pod. Each named port in a pod
-                              must have a unique name. Name for the port that can
-                              be referred to by services.
                             type: string
                           protocol:
                             default: TCP
-                            description: Protocol for port. Must be UDP, TCP, or SCTP.
-                              Defaults to "TCP".
                             type: string
                         required:
                         - containerPort
@@ -1729,71 +852,37 @@ spec:
                       - protocol
                       x-kubernetes-list-type: map
                     readinessProbe:
-                      description: 'Periodic probe of container service readiness.
-                        Container will be removed from service endpoints if the probe
-                        fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                       properties:
                         exec:
-                          description: Exec specifies the action to take.
                           properties:
                             command:
-                              description: Command is the command line to execute
-                                inside the container, the working directory for the
-                                command  is root ('/') in the container's filesystem.
-                                The command is simply exec'd, it is not run inside
-                                a shell, so traditional shell instructions ('|', etc)
-                                won't work. To use a shell, you need to explicitly
-                                call out to that shell. Exit status of 0 is treated
-                                as live/healthy and non-zero is unhealthy.
                               items:
                                 type: string
                               type: array
                           type: object
                         failureThreshold:
-                          description: Minimum consecutive failures for the probe
-                            to be considered failed after having succeeded. Defaults
-                            to 3. Minimum value is 1.
                           format: int32
                           type: integer
                         grpc:
-                          description: GRPC specifies an action involving a GRPC port.
                           properties:
                             port:
-                              description: Port number of the gRPC service. Number
-                                must be in the range 1 to 65535.
                               format: int32
                               type: integer
                             service:
-                              description: "Service is the name of the service to
-                                place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                \n If this is not specified, the default behavior
-                                is defined by gRPC."
                               type: string
                           required:
                           - port
                           type: object
                         httpGet:
-                          description: HTTPGet specifies the http request to perform.
                           properties:
                             host:
-                              description: Host name to connect to, defaults to the
-                                pod IP. You probably want to set "Host" in httpHeaders
-                                instead.
                               type: string
                             httpHeaders:
-                              description: Custom headers to set in the request. HTTP
-                                allows repeated headers.
                               items:
-                                description: HTTPHeader describes a custom header
-                                  to be used in HTTP probes
                                 properties:
                                   name:
-                                    description: The header field name. This will
-                                      be canonicalized upon output, so case-variant
-                                      names will be understood as the same header.
                                     type: string
                                   value:
-                                    description: The header field value
                                     type: string
                                 required:
                                 - name
@@ -1801,97 +890,51 @@ spec:
                                 type: object
                               type: array
                             path:
-                              description: Path to access on the HTTP server.
                               type: string
                             port:
                               anyOf:
                               - type: integer
                               - type: string
-                              description: Name or number of the port to access on
-                                the container. Number must be in the range 1 to 65535.
-                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                             scheme:
-                              description: Scheme to use for connecting to the host.
-                                Defaults to HTTP.
                               type: string
                           required:
                           - port
                           type: object
                         initialDelaySeconds:
-                          description: 'Number of seconds after the container has
-                            started before liveness probes are initiated. More info:
-                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                           format: int32
                           type: integer
                         periodSeconds:
-                          description: How often (in seconds) to perform the probe.
-                            Default to 10 seconds. Minimum value is 1.
                           format: int32
                           type: integer
                         successThreshold:
-                          description: Minimum consecutive successes for the probe
-                            to be considered successful after having failed. Defaults
-                            to 1. Must be 1 for liveness and startup. Minimum value
-                            is 1.
                           format: int32
                           type: integer
                         tcpSocket:
-                          description: TCPSocket specifies an action involving a TCP
-                            port.
                           properties:
                             host:
-                              description: 'Optional: Host name to connect to, defaults
-                                to the pod IP.'
                               type: string
                             port:
                               anyOf:
                               - type: integer
                               - type: string
-                              description: Number or name of the port to access on
-                                the container. Number must be in the range 1 to 65535.
-                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                           required:
                           - port
                           type: object
                         terminationGracePeriodSeconds:
-                          description: Optional duration in seconds the pod needs
-                            to terminate gracefully upon probe failure. The grace
-                            period is the duration in seconds after the processes
-                            running in the pod are sent a termination signal and the
-                            time when the processes are forcibly halted with a kill
-                            signal. Set this value longer than the expected cleanup
-                            time for your process. If this value is nil, the pod's
-                            terminationGracePeriodSeconds will be used. Otherwise,
-                            this value overrides the value provided by the pod spec.
-                            Value must be non-negative integer. The value zero indicates
-                            stop immediately via the kill signal (no opportunity to
-                            shut down). This is a beta field and requires enabling
-                            ProbeTerminationGracePeriod feature gate. Minimum value
-                            is 1. spec.terminationGracePeriodSeconds is used if unset.
                           format: int64
                           type: integer
                         timeoutSeconds:
-                          description: 'Number of seconds after which the probe times
-                            out. Defaults to 1 second. Minimum value is 1. More info:
-                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                           format: int32
                           type: integer
                       type: object
                     resizePolicy:
-                      description: Resources resize policy for the container.
                       items:
-                        description: ContainerResizePolicy represents resource resize
-                          policy for the container.
                         properties:
                           resourceName:
-                            description: 'Name of the resource to which this resource
-                              resize policy applies. Supported values: cpu, memory.'
                             type: string
                           restartPolicy:
-                            description: Restart policy to apply when specified resource
-                              is resized. If not specified, it defaults to NotRequired.
                             type: string
                         required:
                         - resourceName
@@ -1900,23 +943,11 @@ spec:
                       type: array
                       x-kubernetes-list-type: atomic
                     resources:
-                      description: 'Compute Resources required by this container.
-                        Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                       properties:
                         claims:
-                          description: "Claims lists the names of resources, defined
-                            in spec.resourceClaims, that are used by this container.
-                            \n This is an alpha field and requires enabling the DynamicResourceAllocation
-                            feature gate. \n This field is immutable. It can only
-                            be set for containers."
                           items:
-                            description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                             properties:
                               name:
-                                description: Name must match the name of one entry
-                                  in pod.spec.resourceClaims of the Pod where this
-                                  field is used. It makes that resource available
-                                  inside a container.
                                 type: string
                             required:
                             - name
@@ -1932,8 +963,6 @@ spec:
                             - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
-                          description: 'Limits describes the maximum amount of compute
-                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                           type: object
                         requests:
                           additionalProperties:
@@ -1942,275 +971,103 @@ spec:
                             - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
-                          description: 'Requests describes the minimum amount of compute
-                            resources required. If Requests is omitted for a container,
-                            it defaults to Limits if that is explicitly specified,
-                            otherwise to an implementation-defined value. Requests
-                            cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                           type: object
                       type: object
                     restartPolicy:
-                      description: 'RestartPolicy defines the restart behavior of
-                        individual containers in a pod. This field may only be set
-                        for init containers, and the only allowed value is "Always".
-                        For non-init containers or when this field is not specified,
-                        the restart behavior is defined by the Pod''s restart policy
-                        and the container type. Setting the RestartPolicy as "Always"
-                        for the init container will have the following effect: this
-                        init container will be continually restarted on exit until
-                        all regular containers have terminated. Once all regular containers
-                        have completed, all init containers with restartPolicy "Always"
-                        will be shut down. This lifecycle differs from normal init
-                        containers and is often referred to as a "sidecar" container.
-                        Although this init container still starts in the init container
-                        sequence, it does not wait for the container to complete before
-                        proceeding to the next init container. Instead, the next init
-                        container starts immediately after this init container is
-                        started, or after any startupProbe has successfully completed.'
                       type: string
                     securityContext:
-                      description: 'SecurityContext defines the security options the
-                        container should be run with. If set, the fields of SecurityContext
-                        override the equivalent fields of PodSecurityContext. More
-                        info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                       properties:
                         allowPrivilegeEscalation:
-                          description: 'AllowPrivilegeEscalation controls whether
-                            a process can gain more privileges than its parent process.
-                            This bool directly controls if the no_new_privs flag will
-                            be set on the container process. AllowPrivilegeEscalation
-                            is true always when the container is: 1) run as Privileged
-                            2) has CAP_SYS_ADMIN Note that this field cannot be set
-                            when spec.os.name is windows.'
                           type: boolean
                         capabilities:
-                          description: The capabilities to add/drop when running containers.
-                            Defaults to the default set of capabilities granted by
-                            the container runtime. Note that this field cannot be
-                            set when spec.os.name is windows.
                           properties:
                             add:
-                              description: Added capabilities
                               items:
-                                description: Capability represent POSIX capabilities
-                                  type
                                 type: string
                               type: array
                             drop:
-                              description: Removed capabilities
                               items:
-                                description: Capability represent POSIX capabilities
-                                  type
                                 type: string
                               type: array
                           type: object
                         privileged:
-                          description: Run container in privileged mode. Processes
-                            in privileged containers are essentially equivalent to
-                            root on the host. Defaults to false. Note that this field
-                            cannot be set when spec.os.name is windows.
                           type: boolean
                         procMount:
-                          description: procMount denotes the type of proc mount to
-                            use for the containers. The default is DefaultProcMount
-                            which uses the container runtime defaults for readonly
-                            paths and masked paths. This requires the ProcMountType
-                            feature flag to be enabled. Note that this field cannot
-                            be set when spec.os.name is windows.
                           type: string
                         readOnlyRootFilesystem:
-                          description: Whether this container has a read-only root
-                            filesystem. Default is false. Note that this field cannot
-                            be set when spec.os.name is windows.
                           type: boolean
                         runAsGroup:
-                          description: The GID to run the entrypoint of the container
-                            process. Uses runtime default if unset. May also be set
-                            in PodSecurityContext.  If set in both SecurityContext
-                            and PodSecurityContext, the value specified in SecurityContext
-                            takes precedence. Note that this field cannot be set when
-                            spec.os.name is windows.
                           format: int64
                           type: integer
                         runAsNonRoot:
-                          description: Indicates that the container must run as a
-                            non-root user. If true, the Kubelet will validate the
-                            image at runtime to ensure that it does not run as UID
-                            0 (root) and fail to start the container if it does. If
-                            unset or false, no such validation will be performed.
-                            May also be set in PodSecurityContext.  If set in both
-                            SecurityContext and PodSecurityContext, the value specified
-                            in SecurityContext takes precedence.
                           type: boolean
                         runAsUser:
-                          description: The UID to run the entrypoint of the container
-                            process. Defaults to user specified in image metadata
-                            if unspecified. May also be set in PodSecurityContext.  If
-                            set in both SecurityContext and PodSecurityContext, the
-                            value specified in SecurityContext takes precedence. Note
-                            that this field cannot be set when spec.os.name is windows.
                           format: int64
                           type: integer
                         seLinuxOptions:
-                          description: The SELinux context to be applied to the container.
-                            If unspecified, the container runtime will allocate a
-                            random SELinux context for each container.  May also be
-                            set in PodSecurityContext.  If set in both SecurityContext
-                            and PodSecurityContext, the value specified in SecurityContext
-                            takes precedence. Note that this field cannot be set when
-                            spec.os.name is windows.
                           properties:
                             level:
-                              description: Level is SELinux level label that applies
-                                to the container.
                               type: string
                             role:
-                              description: Role is a SELinux role label that applies
-                                to the container.
                               type: string
                             type:
-                              description: Type is a SELinux type label that applies
-                                to the container.
                               type: string
                             user:
-                              description: User is a SELinux user label that applies
-                                to the container.
                               type: string
                           type: object
                         seccompProfile:
-                          description: The seccomp options to use by this container.
-                            If seccomp options are provided at both the pod & container
-                            level, the container options override the pod options.
-                            Note that this field cannot be set when spec.os.name is
-                            windows.
                           properties:
                             localhostProfile:
-                              description: localhostProfile indicates a profile defined
-                                in a file on the node should be used. The profile
-                                must be preconfigured on the node to work. Must be
-                                a descending path, relative to the kubelet's configured
-                                seccomp profile location. Must be set if type is "Localhost".
-                                Must NOT be set for any other type.
                               type: string
                             type:
-                              description: "type indicates which kind of seccomp profile
-                                will be applied. Valid options are: \n Localhost -
-                                a profile defined in a file on the node should be
-                                used. RuntimeDefault - the container runtime default
-                                profile should be used. Unconfined - no profile should
-                                be applied."
                               type: string
                           required:
                           - type
                           type: object
                         windowsOptions:
-                          description: The Windows specific settings applied to all
-                            containers. If unspecified, the options from the PodSecurityContext
-                            will be used. If set in both SecurityContext and PodSecurityContext,
-                            the value specified in SecurityContext takes precedence.
-                            Note that this field cannot be set when spec.os.name is
-                            linux.
                           properties:
                             gmsaCredentialSpec:
-                              description: GMSACredentialSpec is where the GMSA admission
-                                webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                inlines the contents of the GMSA credential spec named
-                                by the GMSACredentialSpecName field.
                               type: string
                             gmsaCredentialSpecName:
-                              description: GMSACredentialSpecName is the name of the
-                                GMSA credential spec to use.
                               type: string
                             hostProcess:
-                              description: HostProcess determines if a container should
-                                be run as a 'Host Process' container. All of a Pod's
-                                containers must have the same effective HostProcess
-                                value (it is not allowed to have a mix of HostProcess
-                                containers and non-HostProcess containers). In addition,
-                                if HostProcess is true then HostNetwork must also
-                                be set to true.
                               type: boolean
                             runAsUserName:
-                              description: The UserName in Windows to run the entrypoint
-                                of the container process. Defaults to the user specified
-                                in image metadata if unspecified. May also be set
-                                in PodSecurityContext. If set in both SecurityContext
-                                and PodSecurityContext, the value specified in SecurityContext
-                                takes precedence.
                               type: string
                           type: object
                       type: object
                     startupProbe:
-                      description: 'StartupProbe indicates that the Pod has successfully
-                        initialized. If specified, no other probes are executed until
-                        this completes successfully. If this probe fails, the Pod
-                        will be restarted, just as if the livenessProbe failed. This
-                        can be used to provide different probe parameters at the beginning
-                        of a Pod''s lifecycle, when it might take a long time to load
-                        data or warm a cache, than during steady-state operation.
-                        This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                       properties:
                         exec:
-                          description: Exec specifies the action to take.
                           properties:
                             command:
-                              description: Command is the command line to execute
-                                inside the container, the working directory for the
-                                command  is root ('/') in the container's filesystem.
-                                The command is simply exec'd, it is not run inside
-                                a shell, so traditional shell instructions ('|', etc)
-                                won't work. To use a shell, you need to explicitly
-                                call out to that shell. Exit status of 0 is treated
-                                as live/healthy and non-zero is unhealthy.
                               items:
                                 type: string
                               type: array
                           type: object
                         failureThreshold:
-                          description: Minimum consecutive failures for the probe
-                            to be considered failed after having succeeded. Defaults
-                            to 3. Minimum value is 1.
                           format: int32
                           type: integer
                         grpc:
-                          description: GRPC specifies an action involving a GRPC port.
                           properties:
                             port:
-                              description: Port number of the gRPC service. Number
-                                must be in the range 1 to 65535.
                               format: int32
                               type: integer
                             service:
-                              description: "Service is the name of the service to
-                                place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                \n If this is not specified, the default behavior
-                                is defined by gRPC."
                               type: string
                           required:
                           - port
                           type: object
                         httpGet:
-                          description: HTTPGet specifies the http request to perform.
                           properties:
                             host:
-                              description: Host name to connect to, defaults to the
-                                pod IP. You probably want to set "Host" in httpHeaders
-                                instead.
                               type: string
                             httpHeaders:
-                              description: Custom headers to set in the request. HTTP
-                                allows repeated headers.
                               items:
-                                description: HTTPHeader describes a custom header
-                                  to be used in HTTP probes
                                 properties:
                                   name:
-                                    description: The header field name. This will
-                                      be canonicalized upon output, so case-variant
-                                      names will be understood as the same header.
                                     type: string
                                   value:
-                                    description: The header field value
                                     type: string
                                 required:
                                 - name
@@ -2218,139 +1075,61 @@ spec:
                                 type: object
                               type: array
                             path:
-                              description: Path to access on the HTTP server.
                               type: string
                             port:
                               anyOf:
                               - type: integer
                               - type: string
-                              description: Name or number of the port to access on
-                                the container. Number must be in the range 1 to 65535.
-                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                             scheme:
-                              description: Scheme to use for connecting to the host.
-                                Defaults to HTTP.
                               type: string
                           required:
                           - port
                           type: object
                         initialDelaySeconds:
-                          description: 'Number of seconds after the container has
-                            started before liveness probes are initiated. More info:
-                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                           format: int32
                           type: integer
                         periodSeconds:
-                          description: How often (in seconds) to perform the probe.
-                            Default to 10 seconds. Minimum value is 1.
                           format: int32
                           type: integer
                         successThreshold:
-                          description: Minimum consecutive successes for the probe
-                            to be considered successful after having failed. Defaults
-                            to 1. Must be 1 for liveness and startup. Minimum value
-                            is 1.
                           format: int32
                           type: integer
                         tcpSocket:
-                          description: TCPSocket specifies an action involving a TCP
-                            port.
                           properties:
                             host:
-                              description: 'Optional: Host name to connect to, defaults
-                                to the pod IP.'
                               type: string
                             port:
                               anyOf:
                               - type: integer
                               - type: string
-                              description: Number or name of the port to access on
-                                the container. Number must be in the range 1 to 65535.
-                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                           required:
                           - port
                           type: object
                         terminationGracePeriodSeconds:
-                          description: Optional duration in seconds the pod needs
-                            to terminate gracefully upon probe failure. The grace
-                            period is the duration in seconds after the processes
-                            running in the pod are sent a termination signal and the
-                            time when the processes are forcibly halted with a kill
-                            signal. Set this value longer than the expected cleanup
-                            time for your process. If this value is nil, the pod's
-                            terminationGracePeriodSeconds will be used. Otherwise,
-                            this value overrides the value provided by the pod spec.
-                            Value must be non-negative integer. The value zero indicates
-                            stop immediately via the kill signal (no opportunity to
-                            shut down). This is a beta field and requires enabling
-                            ProbeTerminationGracePeriod feature gate. Minimum value
-                            is 1. spec.terminationGracePeriodSeconds is used if unset.
                           format: int64
                           type: integer
                         timeoutSeconds:
-                          description: 'Number of seconds after which the probe times
-                            out. Defaults to 1 second. Minimum value is 1. More info:
-                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                           format: int32
                           type: integer
                       type: object
                     stdin:
-                      description: Whether this container should allocate a buffer
-                        for stdin in the container runtime. If this is not set, reads
-                        from stdin in the container will always result in EOF. Default
-                        is false.
                       type: boolean
                     stdinOnce:
-                      description: Whether the container runtime should close the
-                        stdin channel after it has been opened by a single attach.
-                        When stdin is true the stdin stream will remain open across
-                        multiple attach sessions. If stdinOnce is set to true, stdin
-                        is opened on container start, is empty until the first client
-                        attaches to stdin, and then remains open and accepts data
-                        until the client disconnects, at which time stdin is closed
-                        and remains closed until the container is restarted. If this
-                        flag is false, a container processes that reads from stdin
-                        will never receive an EOF. Default is false
                       type: boolean
                     terminationMessagePath:
-                      description: 'Optional: Path at which the file to which the
-                        container''s termination message will be written is mounted
-                        into the container''s filesystem. Message written is intended
-                        to be brief final status, such as an assertion failure message.
-                        Will be truncated by the node if greater than 4096 bytes.
-                        The total message length across all containers will be limited
-                        to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
                       type: string
                     terminationMessagePolicy:
-                      description: Indicate how the termination message should be
-                        populated. File will use the contents of terminationMessagePath
-                        to populate the container status message on both success and
-                        failure. FallbackToLogsOnError will use the last chunk of
-                        container log output if the termination message file is empty
-                        and the container exited with an error. The log output is
-                        limited to 2048 bytes or 80 lines, whichever is smaller. Defaults
-                        to File. Cannot be updated.
                       type: string
                     tty:
-                      description: Whether this container should allocate a TTY for
-                        itself, also requires 'stdin' to be true. Default is false.
                       type: boolean
                     volumeDevices:
-                      description: volumeDevices is the list of block devices to be
-                        used by the container.
                       items:
-                        description: volumeDevice describes a mapping of a raw block
-                          device within a container.
                         properties:
                           devicePath:
-                            description: devicePath is the path inside of the container
-                              that the device will be mapped to.
                             type: string
                           name:
-                            description: name must match the name of a persistentVolumeClaim
-                              in the pod
                             type: string
                         required:
                         - devicePath
@@ -2358,40 +1137,19 @@ spec:
                         type: object
                       type: array
                     volumeMounts:
-                      description: Pod volumes to mount into the container's filesystem.
-                        Cannot be updated.
                       items:
-                        description: VolumeMount describes a mounting of a Volume
-                          within a container.
                         properties:
                           mountPath:
-                            description: Path within the container at which the volume
-                              should be mounted.  Must not contain ':'.
                             type: string
                           mountPropagation:
-                            description: mountPropagation determines how mounts are
-                              propagated from the host to container and the other
-                              way around. When not set, MountPropagationNone is used.
-                              This field is beta in 1.10.
                             type: string
                           name:
-                            description: This must match the Name of a Volume.
                             type: string
                           readOnly:
-                            description: Mounted read-only if true, read-write otherwise
-                              (false or unspecified). Defaults to false.
                             type: boolean
                           subPath:
-                            description: Path within the volume from which the container's
-                              volume should be mounted. Defaults to "" (volume's root).
                             type: string
                           subPathExpr:
-                            description: Expanded path within the volume from which
-                              the container's volume should be mounted. Behaves similarly
-                              to SubPath but environment variable references $(VAR_NAME)
-                              are expanded using the container's environment. Defaults
-                              to "" (volume's root). SubPathExpr and SubPath are mutually
-                              exclusive.
                             type: string
                         required:
                         - mountPath
@@ -2399,9 +1157,6 @@ spec:
                         type: object
                       type: array
                     workingDir:
-                      description: Container's working directory. If not specified,
-                        the container runtime's default will be used, which might
-                        be configured in the container image. Cannot be updated.
                       type: string
                   required:
                   - name
@@ -2409,190 +1164,88 @@ spec:
                 type: array
               disableReporting:
                 default: false
-                description: disableReporting disables reporting of enabled feature
-                  flags to Grafana.
                 type: boolean
               disableSupportBundle:
                 default: false
-                description: disableSupportBundle disables the generation of support
-                  bundles.
                 type: boolean
               enableConfigReadAPI:
                 default: false
-                description: enableConfigReadAPI enables the read API for viewing
-                  the currently running config port 8080 on the agent.
                 type: boolean
               image:
-                description: Image, when specified, overrides the image used to run
-                  Agent. Specify the image along with a tag. You still need to set
-                  the version to ensure Grafana Agent Operator knows which version
-                  of Grafana Agent is being configured.
                 type: string
               imagePullSecrets:
-                description: 'ImagePullSecrets holds an optional list of references
-                  to Secrets within the same namespace used for pulling the Grafana
-                  Agent image from registries. More info: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod'
                 items:
-                  description: LocalObjectReference contains enough information to
-                    let you locate the referenced object inside the same namespace.
                   properties:
                     name:
-                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                        TODO: Add other useful fields. apiVersion, kind, uid?'
                       type: string
                   type: object
                   x-kubernetes-map-type: atomic
                 type: array
               initContainers:
-                description: 'InitContainers let you add initContainers to the pod
-                  definition. These can be used to, for example, fetch secrets for
-                  injection into the Grafana Agent configuration from external sources.
-                  Errors during the execution of an initContainer cause the pod to
-                  restart. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
-                  Using initContainers for any use case other than secret fetching
-                  is entirely outside the scope of what the Grafana Agent maintainers
-                  support and by doing so, you accept that this behavior may break
-                  at any time without notice.'
                 items:
-                  description: A single application container that you want to run
-                    within a pod.
                   properties:
                     args:
-                      description: 'Arguments to the entrypoint. The container image''s
-                        CMD is used if this is not provided. Variable references $(VAR_NAME)
-                        are expanded using the container''s environment. If a variable
-                        cannot be resolved, the reference in the input string will
-                        be unchanged. Double $$ are reduced to a single $, which allows
-                        for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
-                        produce the string literal "$(VAR_NAME)". Escaped references
-                        will never be expanded, regardless of whether the variable
-                        exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                       items:
                         type: string
                       type: array
                     command:
-                      description: 'Entrypoint array. Not executed within a shell.
-                        The container image''s ENTRYPOINT is used if this is not provided.
-                        Variable references $(VAR_NAME) are expanded using the container''s
-                        environment. If a variable cannot be resolved, the reference
-                        in the input string will be unchanged. Double $$ are reduced
-                        to a single $, which allows for escaping the $(VAR_NAME) syntax:
-                        i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
-                        Escaped references will never be expanded, regardless of whether
-                        the variable exists or not. Cannot be updated. More info:
-                        https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                       items:
                         type: string
                       type: array
                     env:
-                      description: List of environment variables to set in the container.
-                        Cannot be updated.
                       items:
-                        description: EnvVar represents an environment variable present
-                          in a Container.
                         properties:
                           name:
-                            description: Name of the environment variable. Must be
-                              a C_IDENTIFIER.
                             type: string
                           value:
-                            description: 'Variable references $(VAR_NAME) are expanded
-                              using the previously defined environment variables in
-                              the container and any service environment variables.
-                              If a variable cannot be resolved, the reference in the
-                              input string will be unchanged. Double $$ are reduced
-                              to a single $, which allows for escaping the $(VAR_NAME)
-                              syntax: i.e. "$$(VAR_NAME)" will produce the string
-                              literal "$(VAR_NAME)". Escaped references will never
-                              be expanded, regardless of whether the variable exists
-                              or not. Defaults to "".'
                             type: string
                           valueFrom:
-                            description: Source for the environment variable's value.
-                              Cannot be used if value is not empty.
                             properties:
                               configMapKeyRef:
-                                description: Selects a key of a ConfigMap.
                                 properties:
                                   key:
-                                    description: The key to select.
                                     type: string
                                   name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
                                     type: string
                                   optional:
-                                    description: Specify whether the ConfigMap or
-                                      its key must be defined
                                     type: boolean
                                 required:
                                 - key
                                 type: object
                                 x-kubernetes-map-type: atomic
                               fieldRef:
-                                description: 'Selects a field of the pod: supports
-                                  metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
-                                  `metadata.annotations[''<KEY>'']`, spec.nodeName,
-                                  spec.serviceAccountName, status.hostIP, status.podIP,
-                                  status.podIPs.'
                                 properties:
                                   apiVersion:
-                                    description: Version of the schema the FieldPath
-                                      is written in terms of, defaults to "v1".
                                     type: string
                                   fieldPath:
-                                    description: Path of the field to select in the
-                                      specified API version.
                                     type: string
                                 required:
                                 - fieldPath
                                 type: object
                                 x-kubernetes-map-type: atomic
                               resourceFieldRef:
-                                description: 'Selects a resource of the container:
-                                  only resources limits and requests (limits.cpu,
-                                  limits.memory, limits.ephemeral-storage, requests.cpu,
-                                  requests.memory and requests.ephemeral-storage)
-                                  are currently supported.'
                                 properties:
                                   containerName:
-                                    description: 'Container name: required for volumes,
-                                      optional for env vars'
                                     type: string
                                   divisor:
                                     anyOf:
                                     - type: integer
                                     - type: string
-                                    description: Specifies the output format of the
-                                      exposed resources, defaults to "1"
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                   resource:
-                                    description: 'Required: resource to select'
                                     type: string
                                 required:
                                 - resource
                                 type: object
                                 x-kubernetes-map-type: atomic
                               secretKeyRef:
-                                description: Selects a key of a secret in the pod's
-                                  namespace
                                 properties:
                                   key:
-                                    description: The key of the secret to select from.  Must
-                                      be a valid secret key.
                                     type: string
                                   name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
                                     type: string
                                   optional:
-                                    description: Specify whether the Secret or its
-                                      key must be defined
                                     type: boolean
                                 required:
                                 - key
@@ -2604,111 +1257,53 @@ spec:
                         type: object
                       type: array
                     envFrom:
-                      description: List of sources to populate environment variables
-                        in the container. The keys defined within a source must be
-                        a C_IDENTIFIER. All invalid keys will be reported as an event
-                        when the container is starting. When a key exists in multiple
-                        sources, the value associated with the last source will take
-                        precedence. Values defined by an Env with a duplicate key
-                        will take precedence. Cannot be updated.
                       items:
-                        description: EnvFromSource represents the source of a set
-                          of ConfigMaps
                         properties:
                           configMapRef:
-                            description: The ConfigMap to select from
                             properties:
                               name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion, kind,
-                                  uid?'
                                 type: string
                               optional:
-                                description: Specify whether the ConfigMap must be
-                                  defined
                                 type: boolean
                             type: object
                             x-kubernetes-map-type: atomic
                           prefix:
-                            description: An optional identifier to prepend to each
-                              key in the ConfigMap. Must be a C_IDENTIFIER.
                             type: string
                           secretRef:
-                            description: The Secret to select from
                             properties:
                               name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion, kind,
-                                  uid?'
                                 type: string
                               optional:
-                                description: Specify whether the Secret must be defined
                                 type: boolean
                             type: object
                             x-kubernetes-map-type: atomic
                         type: object
                       type: array
                     image:
-                      description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images
-                        This field is optional to allow higher level config management
-                        to default or override container images in workload controllers
-                        like Deployments and StatefulSets.'
                       type: string
                     imagePullPolicy:
-                      description: 'Image pull policy. One of Always, Never, IfNotPresent.
-                        Defaults to Always if :latest tag is specified, or IfNotPresent
-                        otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
                       type: string
                     lifecycle:
-                      description: Actions that the management system should take
-                        in response to container lifecycle events. Cannot be updated.
                       properties:
                         postStart:
-                          description: 'PostStart is called immediately after a container
-                            is created. If the handler fails, the container is terminated
-                            and restarted according to its restart policy. Other management
-                            of the container blocks until the hook completes. More
-                            info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                           properties:
                             exec:
-                              description: Exec specifies the action to take.
                               properties:
                                 command:
-                                  description: Command is the command line to execute
-                                    inside the container, the working directory for
-                                    the command  is root ('/') in the container's
-                                    filesystem. The command is simply exec'd, it is
-                                    not run inside a shell, so traditional shell instructions
-                                    ('|', etc) won't work. To use a shell, you need
-                                    to explicitly call out to that shell. Exit status
-                                    of 0 is treated as live/healthy and non-zero is
-                                    unhealthy.
                                   items:
                                     type: string
                                   type: array
                               type: object
                             httpGet:
-                              description: HTTPGet specifies the http request to perform.
                               properties:
                                 host:
-                                  description: Host name to connect to, defaults to
-                                    the pod IP. You probably want to set "Host" in
-                                    httpHeaders instead.
                                   type: string
                                 httpHeaders:
-                                  description: Custom headers to set in the request.
-                                    HTTP allows repeated headers.
                                   items:
-                                    description: HTTPHeader describes a custom header
-                                      to be used in HTTP probes
                                     properties:
                                       name:
-                                        description: The header field name. This will
-                                          be canonicalized upon output, so case-variant
-                                          names will be understood as the same header.
                                         type: string
                                       value:
-                                        description: The header field value
                                         type: string
                                     required:
                                     - name
@@ -2716,97 +1311,49 @@ spec:
                                     type: object
                                   type: array
                                 path:
-                                  description: Path to access on the HTTP server.
                                   type: string
                                 port:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: Name or number of the port to access
-                                    on the container. Number must be in the range
-                                    1 to 65535. Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
                                 scheme:
-                                  description: Scheme to use for connecting to the
-                                    host. Defaults to HTTP.
                                   type: string
                               required:
                               - port
                               type: object
                             tcpSocket:
-                              description: Deprecated. TCPSocket is NOT supported
-                                as a LifecycleHandler and kept for the backward compatibility.
-                                There are no validation of this field and lifecycle
-                                hooks will fail in runtime when tcp handler is specified.
                               properties:
                                 host:
-                                  description: 'Optional: Host name to connect to,
-                                    defaults to the pod IP.'
                                   type: string
                                 port:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: Number or name of the port to access
-                                    on the container. Number must be in the range
-                                    1 to 65535. Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
                               required:
                               - port
                               type: object
                           type: object
                         preStop:
-                          description: 'PreStop is called immediately before a container
-                            is terminated due to an API request or management event
-                            such as liveness/startup probe failure, preemption, resource
-                            contention, etc. The handler is not called if the container
-                            crashes or exits. The Pod''s termination grace period
-                            countdown begins before the PreStop hook is executed.
-                            Regardless of the outcome of the handler, the container
-                            will eventually terminate within the Pod''s termination
-                            grace period (unless delayed by finalizers). Other management
-                            of the container blocks until the hook completes or until
-                            the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                           properties:
                             exec:
-                              description: Exec specifies the action to take.
                               properties:
                                 command:
-                                  description: Command is the command line to execute
-                                    inside the container, the working directory for
-                                    the command  is root ('/') in the container's
-                                    filesystem. The command is simply exec'd, it is
-                                    not run inside a shell, so traditional shell instructions
-                                    ('|', etc) won't work. To use a shell, you need
-                                    to explicitly call out to that shell. Exit status
-                                    of 0 is treated as live/healthy and non-zero is
-                                    unhealthy.
                                   items:
                                     type: string
                                   type: array
                               type: object
                             httpGet:
-                              description: HTTPGet specifies the http request to perform.
                               properties:
                                 host:
-                                  description: Host name to connect to, defaults to
-                                    the pod IP. You probably want to set "Host" in
-                                    httpHeaders instead.
                                   type: string
                                 httpHeaders:
-                                  description: Custom headers to set in the request.
-                                    HTTP allows repeated headers.
                                   items:
-                                    description: HTTPHeader describes a custom header
-                                      to be used in HTTP probes
                                     properties:
                                       name:
-                                        description: The header field name. This will
-                                          be canonicalized upon output, so case-variant
-                                          names will be understood as the same header.
                                         type: string
                                       value:
-                                        description: The header field value
                                         type: string
                                     required:
                                     - name
@@ -2814,40 +1361,25 @@ spec:
                                     type: object
                                   type: array
                                 path:
-                                  description: Path to access on the HTTP server.
                                   type: string
                                 port:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: Name or number of the port to access
-                                    on the container. Number must be in the range
-                                    1 to 65535. Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
                                 scheme:
-                                  description: Scheme to use for connecting to the
-                                    host. Defaults to HTTP.
                                   type: string
                               required:
                               - port
                               type: object
                             tcpSocket:
-                              description: Deprecated. TCPSocket is NOT supported
-                                as a LifecycleHandler and kept for the backward compatibility.
-                                There are no validation of this field and lifecycle
-                                hooks will fail in runtime when tcp handler is specified.
                               properties:
                                 host:
-                                  description: 'Optional: Host name to connect to,
-                                    defaults to the pod IP.'
                                   type: string
                                 port:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: Number or name of the port to access
-                                    on the container. Number must be in the range
-                                    1 to 65535. Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
                               required:
                               - port
@@ -2855,71 +1387,37 @@ spec:
                           type: object
                       type: object
                     livenessProbe:
-                      description: 'Periodic probe of container liveness. Container
-                        will be restarted if the probe fails. Cannot be updated. More
-                        info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                       properties:
                         exec:
-                          description: Exec specifies the action to take.
                           properties:
                             command:
-                              description: Command is the command line to execute
-                                inside the container, the working directory for the
-                                command  is root ('/') in the container's filesystem.
-                                The command is simply exec'd, it is not run inside
-                                a shell, so traditional shell instructions ('|', etc)
-                                won't work. To use a shell, you need to explicitly
-                                call out to that shell. Exit status of 0 is treated
-                                as live/healthy and non-zero is unhealthy.
                               items:
                                 type: string
                               type: array
                           type: object
                         failureThreshold:
-                          description: Minimum consecutive failures for the probe
-                            to be considered failed after having succeeded. Defaults
-                            to 3. Minimum value is 1.
                           format: int32
                           type: integer
                         grpc:
-                          description: GRPC specifies an action involving a GRPC port.
                           properties:
                             port:
-                              description: Port number of the gRPC service. Number
-                                must be in the range 1 to 65535.
                               format: int32
                               type: integer
                             service:
-                              description: "Service is the name of the service to
-                                place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                \n If this is not specified, the default behavior
-                                is defined by gRPC."
                               type: string
                           required:
                           - port
                           type: object
                         httpGet:
-                          description: HTTPGet specifies the http request to perform.
                           properties:
                             host:
-                              description: Host name to connect to, defaults to the
-                                pod IP. You probably want to set "Host" in httpHeaders
-                                instead.
                               type: string
                             httpHeaders:
-                              description: Custom headers to set in the request. HTTP
-                                allows repeated headers.
                               items:
-                                description: HTTPHeader describes a custom header
-                                  to be used in HTTP probes
                                 properties:
                                   name:
-                                    description: The header field name. This will
-                                      be canonicalized upon output, so case-variant
-                                      names will be understood as the same header.
                                     type: string
                                   value:
-                                    description: The header field value
                                     type: string
                                 required:
                                 - name
@@ -2927,126 +1425,62 @@ spec:
                                 type: object
                               type: array
                             path:
-                              description: Path to access on the HTTP server.
                               type: string
                             port:
                               anyOf:
                               - type: integer
                               - type: string
-                              description: Name or number of the port to access on
-                                the container. Number must be in the range 1 to 65535.
-                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                             scheme:
-                              description: Scheme to use for connecting to the host.
-                                Defaults to HTTP.
                               type: string
                           required:
                           - port
                           type: object
                         initialDelaySeconds:
-                          description: 'Number of seconds after the container has
-                            started before liveness probes are initiated. More info:
-                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                           format: int32
                           type: integer
                         periodSeconds:
-                          description: How often (in seconds) to perform the probe.
-                            Default to 10 seconds. Minimum value is 1.
                           format: int32
                           type: integer
                         successThreshold:
-                          description: Minimum consecutive successes for the probe
-                            to be considered successful after having failed. Defaults
-                            to 1. Must be 1 for liveness and startup. Minimum value
-                            is 1.
                           format: int32
                           type: integer
                         tcpSocket:
-                          description: TCPSocket specifies an action involving a TCP
-                            port.
                           properties:
                             host:
-                              description: 'Optional: Host name to connect to, defaults
-                                to the pod IP.'
                               type: string
                             port:
                               anyOf:
                               - type: integer
                               - type: string
-                              description: Number or name of the port to access on
-                                the container. Number must be in the range 1 to 65535.
-                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                           required:
                           - port
                           type: object
                         terminationGracePeriodSeconds:
-                          description: Optional duration in seconds the pod needs
-                            to terminate gracefully upon probe failure. The grace
-                            period is the duration in seconds after the processes
-                            running in the pod are sent a termination signal and the
-                            time when the processes are forcibly halted with a kill
-                            signal. Set this value longer than the expected cleanup
-                            time for your process. If this value is nil, the pod's
-                            terminationGracePeriodSeconds will be used. Otherwise,
-                            this value overrides the value provided by the pod spec.
-                            Value must be non-negative integer. The value zero indicates
-                            stop immediately via the kill signal (no opportunity to
-                            shut down). This is a beta field and requires enabling
-                            ProbeTerminationGracePeriod feature gate. Minimum value
-                            is 1. spec.terminationGracePeriodSeconds is used if unset.
                           format: int64
                           type: integer
                         timeoutSeconds:
-                          description: 'Number of seconds after which the probe times
-                            out. Defaults to 1 second. Minimum value is 1. More info:
-                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                           format: int32
                           type: integer
                       type: object
                     name:
-                      description: Name of the container specified as a DNS_LABEL.
-                        Each container in a pod must have a unique name (DNS_LABEL).
-                        Cannot be updated.
                       type: string
                     ports:
-                      description: List of ports to expose from the container. Not
-                        specifying a port here DOES NOT prevent that port from being
-                        exposed. Any port which is listening on the default "0.0.0.0"
-                        address inside a container will be accessible from the network.
-                        Modifying this array with strategic merge patch may corrupt
-                        the data. For more information See https://github.com/kubernetes/kubernetes/issues/108255.
-                        Cannot be updated.
                       items:
-                        description: ContainerPort represents a network port in a
-                          single container.
                         properties:
                           containerPort:
-                            description: Number of port to expose on the pod's IP
-                              address. This must be a valid port number, 0 < x < 65536.
                             format: int32
                             type: integer
                           hostIP:
-                            description: What host IP to bind the external port to.
                             type: string
                           hostPort:
-                            description: Number of port to expose on the host. If
-                              specified, this must be a valid port number, 0 < x <
-                              65536. If HostNetwork is specified, this must match
-                              ContainerPort. Most containers do not need this.
                             format: int32
                             type: integer
                           name:
-                            description: If specified, this must be an IANA_SVC_NAME
-                              and unique within the pod. Each named port in a pod
-                              must have a unique name. Name for the port that can
-                              be referred to by services.
                             type: string
                           protocol:
                             default: TCP
-                            description: Protocol for port. Must be UDP, TCP, or SCTP.
-                              Defaults to "TCP".
                             type: string
                         required:
                         - containerPort
@@ -3057,71 +1491,37 @@ spec:
                       - protocol
                       x-kubernetes-list-type: map
                     readinessProbe:
-                      description: 'Periodic probe of container service readiness.
-                        Container will be removed from service endpoints if the probe
-                        fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                       properties:
                         exec:
-                          description: Exec specifies the action to take.
                           properties:
                             command:
-                              description: Command is the command line to execute
-                                inside the container, the working directory for the
-                                command  is root ('/') in the container's filesystem.
-                                The command is simply exec'd, it is not run inside
-                                a shell, so traditional shell instructions ('|', etc)
-                                won't work. To use a shell, you need to explicitly
-                                call out to that shell. Exit status of 0 is treated
-                                as live/healthy and non-zero is unhealthy.
                               items:
                                 type: string
                               type: array
                           type: object
                         failureThreshold:
-                          description: Minimum consecutive failures for the probe
-                            to be considered failed after having succeeded. Defaults
-                            to 3. Minimum value is 1.
                           format: int32
                           type: integer
                         grpc:
-                          description: GRPC specifies an action involving a GRPC port.
                           properties:
                             port:
-                              description: Port number of the gRPC service. Number
-                                must be in the range 1 to 65535.
                               format: int32
                               type: integer
                             service:
-                              description: "Service is the name of the service to
-                                place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                \n If this is not specified, the default behavior
-                                is defined by gRPC."
                               type: string
                           required:
                           - port
                           type: object
                         httpGet:
-                          description: HTTPGet specifies the http request to perform.
                           properties:
                             host:
-                              description: Host name to connect to, defaults to the
-                                pod IP. You probably want to set "Host" in httpHeaders
-                                instead.
                               type: string
                             httpHeaders:
-                              description: Custom headers to set in the request. HTTP
-                                allows repeated headers.
                               items:
-                                description: HTTPHeader describes a custom header
-                                  to be used in HTTP probes
                                 properties:
                                   name:
-                                    description: The header field name. This will
-                                      be canonicalized upon output, so case-variant
-                                      names will be understood as the same header.
                                     type: string
                                   value:
-                                    description: The header field value
                                     type: string
                                 required:
                                 - name
@@ -3129,97 +1529,51 @@ spec:
                                 type: object
                               type: array
                             path:
-                              description: Path to access on the HTTP server.
                               type: string
                             port:
                               anyOf:
                               - type: integer
                               - type: string
-                              description: Name or number of the port to access on
-                                the container. Number must be in the range 1 to 65535.
-                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                             scheme:
-                              description: Scheme to use for connecting to the host.
-                                Defaults to HTTP.
                               type: string
                           required:
                           - port
                           type: object
                         initialDelaySeconds:
-                          description: 'Number of seconds after the container has
-                            started before liveness probes are initiated. More info:
-                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                           format: int32
                           type: integer
                         periodSeconds:
-                          description: How often (in seconds) to perform the probe.
-                            Default to 10 seconds. Minimum value is 1.
                           format: int32
                           type: integer
                         successThreshold:
-                          description: Minimum consecutive successes for the probe
-                            to be considered successful after having failed. Defaults
-                            to 1. Must be 1 for liveness and startup. Minimum value
-                            is 1.
                           format: int32
                           type: integer
                         tcpSocket:
-                          description: TCPSocket specifies an action involving a TCP
-                            port.
                           properties:
                             host:
-                              description: 'Optional: Host name to connect to, defaults
-                                to the pod IP.'
                               type: string
                             port:
                               anyOf:
                               - type: integer
                               - type: string
-                              description: Number or name of the port to access on
-                                the container. Number must be in the range 1 to 65535.
-                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                           required:
                           - port
                           type: object
                         terminationGracePeriodSeconds:
-                          description: Optional duration in seconds the pod needs
-                            to terminate gracefully upon probe failure. The grace
-                            period is the duration in seconds after the processes
-                            running in the pod are sent a termination signal and the
-                            time when the processes are forcibly halted with a kill
-                            signal. Set this value longer than the expected cleanup
-                            time for your process. If this value is nil, the pod's
-                            terminationGracePeriodSeconds will be used. Otherwise,
-                            this value overrides the value provided by the pod spec.
-                            Value must be non-negative integer. The value zero indicates
-                            stop immediately via the kill signal (no opportunity to
-                            shut down). This is a beta field and requires enabling
-                            ProbeTerminationGracePeriod feature gate. Minimum value
-                            is 1. spec.terminationGracePeriodSeconds is used if unset.
                           format: int64
                           type: integer
                         timeoutSeconds:
-                          description: 'Number of seconds after which the probe times
-                            out. Defaults to 1 second. Minimum value is 1. More info:
-                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                           format: int32
                           type: integer
                       type: object
                     resizePolicy:
-                      description: Resources resize policy for the container.
                       items:
-                        description: ContainerResizePolicy represents resource resize
-                          policy for the container.
                         properties:
                           resourceName:
-                            description: 'Name of the resource to which this resource
-                              resize policy applies. Supported values: cpu, memory.'
                             type: string
                           restartPolicy:
-                            description: Restart policy to apply when specified resource
-                              is resized. If not specified, it defaults to NotRequired.
                             type: string
                         required:
                         - resourceName
@@ -3228,23 +1582,11 @@ spec:
                       type: array
                       x-kubernetes-list-type: atomic
                     resources:
-                      description: 'Compute Resources required by this container.
-                        Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                       properties:
                         claims:
-                          description: "Claims lists the names of resources, defined
-                            in spec.resourceClaims, that are used by this container.
-                            \n This is an alpha field and requires enabling the DynamicResourceAllocation
-                            feature gate. \n This field is immutable. It can only
-                            be set for containers."
                           items:
-                            description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                             properties:
                               name:
-                                description: Name must match the name of one entry
-                                  in pod.spec.resourceClaims of the Pod where this
-                                  field is used. It makes that resource available
-                                  inside a container.
                                 type: string
                             required:
                             - name
@@ -3260,8 +1602,6 @@ spec:
                             - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
-                          description: 'Limits describes the maximum amount of compute
-                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                           type: object
                         requests:
                           additionalProperties:
@@ -3270,275 +1610,103 @@ spec:
                             - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
-                          description: 'Requests describes the minimum amount of compute
-                            resources required. If Requests is omitted for a container,
-                            it defaults to Limits if that is explicitly specified,
-                            otherwise to an implementation-defined value. Requests
-                            cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                           type: object
                       type: object
                     restartPolicy:
-                      description: 'RestartPolicy defines the restart behavior of
-                        individual containers in a pod. This field may only be set
-                        for init containers, and the only allowed value is "Always".
-                        For non-init containers or when this field is not specified,
-                        the restart behavior is defined by the Pod''s restart policy
-                        and the container type. Setting the RestartPolicy as "Always"
-                        for the init container will have the following effect: this
-                        init container will be continually restarted on exit until
-                        all regular containers have terminated. Once all regular containers
-                        have completed, all init containers with restartPolicy "Always"
-                        will be shut down. This lifecycle differs from normal init
-                        containers and is often referred to as a "sidecar" container.
-                        Although this init container still starts in the init container
-                        sequence, it does not wait for the container to complete before
-                        proceeding to the next init container. Instead, the next init
-                        container starts immediately after this init container is
-                        started, or after any startupProbe has successfully completed.'
                       type: string
                     securityContext:
-                      description: 'SecurityContext defines the security options the
-                        container should be run with. If set, the fields of SecurityContext
-                        override the equivalent fields of PodSecurityContext. More
-                        info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                       properties:
                         allowPrivilegeEscalation:
-                          description: 'AllowPrivilegeEscalation controls whether
-                            a process can gain more privileges than its parent process.
-                            This bool directly controls if the no_new_privs flag will
-                            be set on the container process. AllowPrivilegeEscalation
-                            is true always when the container is: 1) run as Privileged
-                            2) has CAP_SYS_ADMIN Note that this field cannot be set
-                            when spec.os.name is windows.'
                           type: boolean
                         capabilities:
-                          description: The capabilities to add/drop when running containers.
-                            Defaults to the default set of capabilities granted by
-                            the container runtime. Note that this field cannot be
-                            set when spec.os.name is windows.
                           properties:
                             add:
-                              description: Added capabilities
                               items:
-                                description: Capability represent POSIX capabilities
-                                  type
                                 type: string
                               type: array
                             drop:
-                              description: Removed capabilities
                               items:
-                                description: Capability represent POSIX capabilities
-                                  type
                                 type: string
                               type: array
                           type: object
                         privileged:
-                          description: Run container in privileged mode. Processes
-                            in privileged containers are essentially equivalent to
-                            root on the host. Defaults to false. Note that this field
-                            cannot be set when spec.os.name is windows.
                           type: boolean
                         procMount:
-                          description: procMount denotes the type of proc mount to
-                            use for the containers. The default is DefaultProcMount
-                            which uses the container runtime defaults for readonly
-                            paths and masked paths. This requires the ProcMountType
-                            feature flag to be enabled. Note that this field cannot
-                            be set when spec.os.name is windows.
                           type: string
                         readOnlyRootFilesystem:
-                          description: Whether this container has a read-only root
-                            filesystem. Default is false. Note that this field cannot
-                            be set when spec.os.name is windows.
                           type: boolean
                         runAsGroup:
-                          description: The GID to run the entrypoint of the container
-                            process. Uses runtime default if unset. May also be set
-                            in PodSecurityContext.  If set in both SecurityContext
-                            and PodSecurityContext, the value specified in SecurityContext
-                            takes precedence. Note that this field cannot be set when
-                            spec.os.name is windows.
                           format: int64
                           type: integer
                         runAsNonRoot:
-                          description: Indicates that the container must run as a
-                            non-root user. If true, the Kubelet will validate the
-                            image at runtime to ensure that it does not run as UID
-                            0 (root) and fail to start the container if it does. If
-                            unset or false, no such validation will be performed.
-                            May also be set in PodSecurityContext.  If set in both
-                            SecurityContext and PodSecurityContext, the value specified
-                            in SecurityContext takes precedence.
                           type: boolean
                         runAsUser:
-                          description: The UID to run the entrypoint of the container
-                            process. Defaults to user specified in image metadata
-                            if unspecified. May also be set in PodSecurityContext.  If
-                            set in both SecurityContext and PodSecurityContext, the
-                            value specified in SecurityContext takes precedence. Note
-                            that this field cannot be set when spec.os.name is windows.
                           format: int64
                           type: integer
                         seLinuxOptions:
-                          description: The SELinux context to be applied to the container.
-                            If unspecified, the container runtime will allocate a
-                            random SELinux context for each container.  May also be
-                            set in PodSecurityContext.  If set in both SecurityContext
-                            and PodSecurityContext, the value specified in SecurityContext
-                            takes precedence. Note that this field cannot be set when
-                            spec.os.name is windows.
                           properties:
                             level:
-                              description: Level is SELinux level label that applies
-                                to the container.
                               type: string
                             role:
-                              description: Role is a SELinux role label that applies
-                                to the container.
                               type: string
                             type:
-                              description: Type is a SELinux type label that applies
-                                to the container.
                               type: string
                             user:
-                              description: User is a SELinux user label that applies
-                                to the container.
                               type: string
                           type: object
                         seccompProfile:
-                          description: The seccomp options to use by this container.
-                            If seccomp options are provided at both the pod & container
-                            level, the container options override the pod options.
-                            Note that this field cannot be set when spec.os.name is
-                            windows.
                           properties:
                             localhostProfile:
-                              description: localhostProfile indicates a profile defined
-                                in a file on the node should be used. The profile
-                                must be preconfigured on the node to work. Must be
-                                a descending path, relative to the kubelet's configured
-                                seccomp profile location. Must be set if type is "Localhost".
-                                Must NOT be set for any other type.
                               type: string
                             type:
-                              description: "type indicates which kind of seccomp profile
-                                will be applied. Valid options are: \n Localhost -
-                                a profile defined in a file on the node should be
-                                used. RuntimeDefault - the container runtime default
-                                profile should be used. Unconfined - no profile should
-                                be applied."
                               type: string
                           required:
                           - type
                           type: object
                         windowsOptions:
-                          description: The Windows specific settings applied to all
-                            containers. If unspecified, the options from the PodSecurityContext
-                            will be used. If set in both SecurityContext and PodSecurityContext,
-                            the value specified in SecurityContext takes precedence.
-                            Note that this field cannot be set when spec.os.name is
-                            linux.
                           properties:
                             gmsaCredentialSpec:
-                              description: GMSACredentialSpec is where the GMSA admission
-                                webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                inlines the contents of the GMSA credential spec named
-                                by the GMSACredentialSpecName field.
                               type: string
                             gmsaCredentialSpecName:
-                              description: GMSACredentialSpecName is the name of the
-                                GMSA credential spec to use.
                               type: string
                             hostProcess:
-                              description: HostProcess determines if a container should
-                                be run as a 'Host Process' container. All of a Pod's
-                                containers must have the same effective HostProcess
-                                value (it is not allowed to have a mix of HostProcess
-                                containers and non-HostProcess containers). In addition,
-                                if HostProcess is true then HostNetwork must also
-                                be set to true.
                               type: boolean
                             runAsUserName:
-                              description: The UserName in Windows to run the entrypoint
-                                of the container process. Defaults to the user specified
-                                in image metadata if unspecified. May also be set
-                                in PodSecurityContext. If set in both SecurityContext
-                                and PodSecurityContext, the value specified in SecurityContext
-                                takes precedence.
                               type: string
                           type: object
                       type: object
                     startupProbe:
-                      description: 'StartupProbe indicates that the Pod has successfully
-                        initialized. If specified, no other probes are executed until
-                        this completes successfully. If this probe fails, the Pod
-                        will be restarted, just as if the livenessProbe failed. This
-                        can be used to provide different probe parameters at the beginning
-                        of a Pod''s lifecycle, when it might take a long time to load
-                        data or warm a cache, than during steady-state operation.
-                        This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                       properties:
                         exec:
-                          description: Exec specifies the action to take.
                           properties:
                             command:
-                              description: Command is the command line to execute
-                                inside the container, the working directory for the
-                                command  is root ('/') in the container's filesystem.
-                                The command is simply exec'd, it is not run inside
-                                a shell, so traditional shell instructions ('|', etc)
-                                won't work. To use a shell, you need to explicitly
-                                call out to that shell. Exit status of 0 is treated
-                                as live/healthy and non-zero is unhealthy.
                               items:
                                 type: string
                               type: array
                           type: object
                         failureThreshold:
-                          description: Minimum consecutive failures for the probe
-                            to be considered failed after having succeeded. Defaults
-                            to 3. Minimum value is 1.
                           format: int32
                           type: integer
                         grpc:
-                          description: GRPC specifies an action involving a GRPC port.
                           properties:
                             port:
-                              description: Port number of the gRPC service. Number
-                                must be in the range 1 to 65535.
                               format: int32
                               type: integer
                             service:
-                              description: "Service is the name of the service to
-                                place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                \n If this is not specified, the default behavior
-                                is defined by gRPC."
                               type: string
                           required:
                           - port
                           type: object
                         httpGet:
-                          description: HTTPGet specifies the http request to perform.
                           properties:
                             host:
-                              description: Host name to connect to, defaults to the
-                                pod IP. You probably want to set "Host" in httpHeaders
-                                instead.
                               type: string
                             httpHeaders:
-                              description: Custom headers to set in the request. HTTP
-                                allows repeated headers.
                               items:
-                                description: HTTPHeader describes a custom header
-                                  to be used in HTTP probes
                                 properties:
                                   name:
-                                    description: The header field name. This will
-                                      be canonicalized upon output, so case-variant
-                                      names will be understood as the same header.
                                     type: string
                                   value:
-                                    description: The header field value
                                     type: string
                                 required:
                                 - name
@@ -3546,139 +1714,61 @@ spec:
                                 type: object
                               type: array
                             path:
-                              description: Path to access on the HTTP server.
                               type: string
                             port:
                               anyOf:
                               - type: integer
                               - type: string
-                              description: Name or number of the port to access on
-                                the container. Number must be in the range 1 to 65535.
-                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                             scheme:
-                              description: Scheme to use for connecting to the host.
-                                Defaults to HTTP.
                               type: string
                           required:
                           - port
                           type: object
                         initialDelaySeconds:
-                          description: 'Number of seconds after the container has
-                            started before liveness probes are initiated. More info:
-                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                           format: int32
                           type: integer
                         periodSeconds:
-                          description: How often (in seconds) to perform the probe.
-                            Default to 10 seconds. Minimum value is 1.
                           format: int32
                           type: integer
                         successThreshold:
-                          description: Minimum consecutive successes for the probe
-                            to be considered successful after having failed. Defaults
-                            to 1. Must be 1 for liveness and startup. Minimum value
-                            is 1.
                           format: int32
                           type: integer
                         tcpSocket:
-                          description: TCPSocket specifies an action involving a TCP
-                            port.
                           properties:
                             host:
-                              description: 'Optional: Host name to connect to, defaults
-                                to the pod IP.'
                               type: string
                             port:
                               anyOf:
                               - type: integer
                               - type: string
-                              description: Number or name of the port to access on
-                                the container. Number must be in the range 1 to 65535.
-                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                           required:
                           - port
                           type: object
                         terminationGracePeriodSeconds:
-                          description: Optional duration in seconds the pod needs
-                            to terminate gracefully upon probe failure. The grace
-                            period is the duration in seconds after the processes
-                            running in the pod are sent a termination signal and the
-                            time when the processes are forcibly halted with a kill
-                            signal. Set this value longer than the expected cleanup
-                            time for your process. If this value is nil, the pod's
-                            terminationGracePeriodSeconds will be used. Otherwise,
-                            this value overrides the value provided by the pod spec.
-                            Value must be non-negative integer. The value zero indicates
-                            stop immediately via the kill signal (no opportunity to
-                            shut down). This is a beta field and requires enabling
-                            ProbeTerminationGracePeriod feature gate. Minimum value
-                            is 1. spec.terminationGracePeriodSeconds is used if unset.
                           format: int64
                           type: integer
                         timeoutSeconds:
-                          description: 'Number of seconds after which the probe times
-                            out. Defaults to 1 second. Minimum value is 1. More info:
-                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                           format: int32
                           type: integer
                       type: object
                     stdin:
-                      description: Whether this container should allocate a buffer
-                        for stdin in the container runtime. If this is not set, reads
-                        from stdin in the container will always result in EOF. Default
-                        is false.
                       type: boolean
                     stdinOnce:
-                      description: Whether the container runtime should close the
-                        stdin channel after it has been opened by a single attach.
-                        When stdin is true the stdin stream will remain open across
-                        multiple attach sessions. If stdinOnce is set to true, stdin
-                        is opened on container start, is empty until the first client
-                        attaches to stdin, and then remains open and accepts data
-                        until the client disconnects, at which time stdin is closed
-                        and remains closed until the container is restarted. If this
-                        flag is false, a container processes that reads from stdin
-                        will never receive an EOF. Default is false
                       type: boolean
                     terminationMessagePath:
-                      description: 'Optional: Path at which the file to which the
-                        container''s termination message will be written is mounted
-                        into the container''s filesystem. Message written is intended
-                        to be brief final status, such as an assertion failure message.
-                        Will be truncated by the node if greater than 4096 bytes.
-                        The total message length across all containers will be limited
-                        to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
                       type: string
                     terminationMessagePolicy:
-                      description: Indicate how the termination message should be
-                        populated. File will use the contents of terminationMessagePath
-                        to populate the container status message on both success and
-                        failure. FallbackToLogsOnError will use the last chunk of
-                        container log output if the termination message file is empty
-                        and the container exited with an error. The log output is
-                        limited to 2048 bytes or 80 lines, whichever is smaller. Defaults
-                        to File. Cannot be updated.
                       type: string
                     tty:
-                      description: Whether this container should allocate a TTY for
-                        itself, also requires 'stdin' to be true. Default is false.
                       type: boolean
                     volumeDevices:
-                      description: volumeDevices is the list of block devices to be
-                        used by the container.
                       items:
-                        description: volumeDevice describes a mapping of a raw block
-                          device within a container.
                         properties:
                           devicePath:
-                            description: devicePath is the path inside of the container
-                              that the device will be mapped to.
                             type: string
                           name:
-                            description: name must match the name of a persistentVolumeClaim
-                              in the pod
                             type: string
                         required:
                         - devicePath
@@ -3686,40 +1776,19 @@ spec:
                         type: object
                       type: array
                     volumeMounts:
-                      description: Pod volumes to mount into the container's filesystem.
-                        Cannot be updated.
                       items:
-                        description: VolumeMount describes a mounting of a Volume
-                          within a container.
                         properties:
                           mountPath:
-                            description: Path within the container at which the volume
-                              should be mounted.  Must not contain ':'.
                             type: string
                           mountPropagation:
-                            description: mountPropagation determines how mounts are
-                              propagated from the host to container and the other
-                              way around. When not set, MountPropagationNone is used.
-                              This field is beta in 1.10.
                             type: string
                           name:
-                            description: This must match the Name of a Volume.
                             type: string
                           readOnly:
-                            description: Mounted read-only if true, read-write otherwise
-                              (false or unspecified). Defaults to false.
                             type: boolean
                           subPath:
-                            description: Path within the volume from which the container's
-                              volume should be mounted. Defaults to "" (volume's root).
                             type: string
                           subPathExpr:
-                            description: Expanded path within the volume from which
-                              the container's volume should be mounted. Behaves similarly
-                              to SubPath but environment variable references $(VAR_NAME)
-                              are expanded using the container's environment. Defaults
-                              to "" (volume's root). SubPathExpr and SubPath are mutually
-                              exclusive.
                             type: string
                         required:
                         - mountPath
@@ -3727,47 +1796,23 @@ spec:
                         type: object
                       type: array
                     workingDir:
-                      description: Container's working directory. If not specified,
-                        the container runtime's default will be used, which might
-                        be configured in the container image. Cannot be updated.
                       type: string
                   required:
                   - name
                   type: object
                 type: array
               integrations:
-                description: Integrations controls the integration subsystem of the
-                  Agent and settings unique to deployed integration-specific pods.
                 properties:
                   namespaceSelector:
-                    description: "Label selector for namespaces to search when discovering
-                      integration resources. If nil, integration resources are only
-                      discovered in the namespace of the GrafanaAgent resource. \n
-                      Set to `{}` to search all namespaces."
                     properties:
                       matchExpressions:
-                        description: matchExpressions is a list of label selector
-                          requirements. The requirements are ANDed.
                         items:
-                          description: A label selector requirement is a selector
-                            that contains values, a key, and an operator that relates
-                            the key and values.
                           properties:
                             key:
-                              description: key is the label key that the selector
-                                applies to.
                               type: string
                             operator:
-                              description: operator represents a key's relationship
-                                to a set of values. Valid operators are In, NotIn,
-                                Exists and DoesNotExist.
                               type: string
                             values:
-                              description: values is an array of string values. If
-                                the operator is In or NotIn, the values array must
-                                be non-empty. If the operator is Exists or DoesNotExist,
-                                the values array must be empty. This array is replaced
-                                during a strategic merge patch.
                               items:
                                 type: string
                               type: array
@@ -3779,41 +1824,19 @@ spec:
                       matchLabels:
                         additionalProperties:
                           type: string
-                        description: matchLabels is a map of {key,value} pairs. A
-                          single {key,value} in the matchLabels map is equivalent
-                          to an element of matchExpressions, whose key field is "key",
-                          the operator is "In", and the values array contains only
-                          "value". The requirements are ANDed.
                         type: object
                     type: object
                     x-kubernetes-map-type: atomic
                   selector:
-                    description: Label selector to find Integration resources to run.
-                      When nil, no integration resources will be defined.
                     properties:
                       matchExpressions:
-                        description: matchExpressions is a list of label selector
-                          requirements. The requirements are ANDed.
                         items:
-                          description: A label selector requirement is a selector
-                            that contains values, a key, and an operator that relates
-                            the key and values.
                           properties:
                             key:
-                              description: key is the label key that the selector
-                                applies to.
                               type: string
                             operator:
-                              description: operator represents a key's relationship
-                                to a set of values. Valid operators are In, NotIn,
-                                Exists and DoesNotExist.
                               type: string
                             values:
-                              description: values is an array of string values. If
-                                the operator is In or NotIn, the values array must
-                                be non-empty. If the operator is Exists or DoesNotExist,
-                                the values array must be empty. This array is replaced
-                                during a strategic merge patch.
                               items:
                                 type: string
                               type: array
@@ -3825,91 +1848,49 @@ spec:
                       matchLabels:
                         additionalProperties:
                           type: string
-                        description: matchLabels is a map of {key,value} pairs. A
-                          single {key,value} in the matchLabels map is equivalent
-                          to an element of matchExpressions, whose key field is "key",
-                          the operator is "In", and the values array contains only
-                          "value". The requirements are ANDed.
                         type: object
                     type: object
                     x-kubernetes-map-type: atomic
                 type: object
               logFormat:
-                description: LogFormat controls the logging format of the generated
-                  pods. Defaults to "logfmt" if not set.
                 type: string
               logLevel:
-                description: LogLevel controls the log level of the generated pods.
-                  Defaults to "info" if not set.
                 type: string
               logs:
-                description: Logs controls the logging subsystem of the Agent and
-                  settings unique to logging-specific pods that are deployed.
                 properties:
                   clients:
-                    description: A global set of clients to use when a discovered
-                      LogsInstance does not have any clients defined.
                     items:
-                      description: LogsClientSpec defines the client integration for
-                        logs, indicating which Loki server to send logs to.
                       properties:
                         backoffConfig:
-                          description: Configures how to retry requests to Loki when
-                            a request fails. Defaults to a minPeriod of 500ms, maxPeriod
-                            of 5m, and maxRetries of 10.
                           properties:
                             maxPeriod:
-                              description: Maximum backoff time between retries.
                               type: string
                             maxRetries:
-                              description: Maximum number of retries to perform before
-                                giving up a request.
                               type: integer
                             minPeriod:
-                              description: Initial backoff time between retries. Time
-                                between retries is increased exponentially.
                               type: string
                           type: object
                         basicAuth:
-                          description: BasicAuth for the Loki server.
                           properties:
                             password:
-                              description: The secret in the service monitor namespace
-                                that contains the password for authentication.
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must
-                                    be a valid secret key.
                                   type: string
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
-                                    must be defined
                                   type: boolean
                               required:
                               - key
                               type: object
                               x-kubernetes-map-type: atomic
                             username:
-                              description: The secret in the service monitor namespace
-                                that contains the username for authentication.
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must
-                                    be a valid secret key.
                                   type: string
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
-                                    must be defined
                                   type: boolean
                               required:
                               - key
@@ -3917,70 +1898,40 @@ spec:
                               x-kubernetes-map-type: atomic
                           type: object
                         batchSize:
-                          description: Maximum batch size (in bytes) of logs to accumulate
-                            before sending the batch to Loki.
                           type: integer
                         batchWait:
-                          description: Maximum amount of time to wait before sending
-                            a batch, even if that batch isn't full.
                           type: string
                         bearerToken:
-                          description: BearerToken used for remote_write.
                           type: string
                         bearerTokenFile:
-                          description: BearerTokenFile used to read bearer token.
                           type: string
                         externalLabels:
                           additionalProperties:
                             type: string
-                          description: ExternalLabels are labels to add to any time
-                            series when sending data to Loki.
                           type: object
                         oauth2:
-                          description: Oauth2 for URL
                           properties:
                             clientId:
-                              description: The secret or configmap containing the
-                                OAuth2 client id
                               properties:
                                 configMap:
-                                  description: ConfigMap containing data to use for
-                                    the targets.
                                   properties:
                                     key:
-                                      description: The key to select.
                                       type: string
                                     name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
                                       type: string
                                     optional:
-                                      description: Specify whether the ConfigMap or
-                                        its key must be defined
                                       type: boolean
                                   required:
                                   - key
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 secret:
-                                  description: Secret containing data to use for the
-                                    targets.
                                   properties:
                                     key:
-                                      description: The key of the secret to select
-                                        from.  Must be a valid secret key.
                                       type: string
                                     name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
                                       type: string
                                     optional:
-                                      description: Specify whether the Secret or its
-                                        key must be defined
                                       type: boolean
                                   required:
                                   - key
@@ -3988,21 +1939,12 @@ spec:
                                   x-kubernetes-map-type: atomic
                               type: object
                             clientSecret:
-                              description: The secret containing the OAuth2 client
-                                secret
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must
-                                    be a valid secret key.
                                   type: string
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
-                                    must be defined
                                   type: boolean
                               required:
                               - key
@@ -4011,15 +1953,12 @@ spec:
                             endpointParams:
                               additionalProperties:
                                 type: string
-                              description: Parameters to append to the token URL
                               type: object
                             scopes:
-                              description: OAuth2 scopes used for the token request
                               items:
                                 type: string
                               type: array
                             tokenUrl:
-                              description: The URL to fetch the token from
                               minLength: 1
                               type: string
                           required:
@@ -4028,64 +1967,34 @@ spec:
                           - tokenUrl
                           type: object
                         proxyUrl:
-                          description: ProxyURL to proxy requests through. Optional.
                           type: string
                         tenantId:
-                          description: Tenant ID used by default to push logs to Loki.
-                            If omitted assumes remote Loki is running in single-tenant
-                            mode or an authentication layer is used to inject an X-Scope-OrgID
-                            header.
                           type: string
                         timeout:
-                          description: Maximum time to wait for a server to respond
-                            to a request.
                           type: string
                         tlsConfig:
-                          description: TLSConfig to use for the client. Only used
-                            when the protocol of the URL is https.
                           properties:
                             ca:
-                              description: Certificate authority used when verifying
-                                server certificates.
                               properties:
                                 configMap:
-                                  description: ConfigMap containing data to use for
-                                    the targets.
                                   properties:
                                     key:
-                                      description: The key to select.
                                       type: string
                                     name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
                                       type: string
                                     optional:
-                                      description: Specify whether the ConfigMap or
-                                        its key must be defined
                                       type: boolean
                                   required:
                                   - key
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 secret:
-                                  description: Secret containing data to use for the
-                                    targets.
                                   properties:
                                     key:
-                                      description: The key of the secret to select
-                                        from.  Must be a valid secret key.
                                       type: string
                                     name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
                                       type: string
                                     optional:
-                                      description: Specify whether the Secret or its
-                                        key must be defined
                                       type: boolean
                                   required:
                                   - key
@@ -4093,51 +2002,28 @@ spec:
                                   x-kubernetes-map-type: atomic
                               type: object
                             caFile:
-                              description: Path to the CA cert in the Prometheus container
-                                to use for the targets.
                               type: string
                             cert:
-                              description: Client certificate to present when doing
-                                client-authentication.
                               properties:
                                 configMap:
-                                  description: ConfigMap containing data to use for
-                                    the targets.
                                   properties:
                                     key:
-                                      description: The key to select.
                                       type: string
                                     name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
                                       type: string
                                     optional:
-                                      description: Specify whether the ConfigMap or
-                                        its key must be defined
                                       type: boolean
                                   required:
                                   - key
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 secret:
-                                  description: Secret containing data to use for the
-                                    targets.
                                   properties:
                                     key:
-                                      description: The key of the secret to select
-                                        from.  Must be a valid secret key.
                                       type: string
                                     name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
                                       type: string
                                     optional:
-                                      description: Specify whether the Secret or its
-                                        key must be defined
                                       type: boolean
                                   required:
                                   - key
@@ -4145,89 +2031,46 @@ spec:
                                   x-kubernetes-map-type: atomic
                               type: object
                             certFile:
-                              description: Path to the client cert file in the Prometheus
-                                container for the targets.
                               type: string
                             insecureSkipVerify:
-                              description: Disable target certificate validation.
                               type: boolean
                             keyFile:
-                              description: Path to the client key file in the Prometheus
-                                container for the targets.
                               type: string
                             keySecret:
-                              description: Secret containing the client key file for
-                                the targets.
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must
-                                    be a valid secret key.
                                   type: string
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
-                                    must be defined
                                   type: boolean
                               required:
                               - key
                               type: object
                               x-kubernetes-map-type: atomic
                             serverName:
-                              description: Used to verify the hostname for the targets.
                               type: string
                           type: object
                         url:
-                          description: 'URL is the URL where Loki is listening. Must
-                            be a full HTTP URL, including protocol. Required. Example:
-                            https://logs-prod-us-central1.grafana.net/loki/api/v1/push.'
                           type: string
                       required:
                       - url
                       type: object
                     type: array
                   enforcedNamespaceLabel:
-                    description: EnforcedNamespaceLabel enforces adding a namespace
-                      label of origin for each metric that is user-created. The label
-                      value will always be the namespace of the object that is being
-                      created.
                     type: string
                   ignoreNamespaceSelectors:
-                    description: IgnoreNamespaceSelectors, if true, will ignore NamespaceSelector
-                      settings from the PodLogs configs, and they will only discover
-                      endpoints within their current namespace.
                     type: boolean
                   instanceNamespaceSelector:
-                    description: InstanceNamespaceSelector are the set of labels to
-                      determine which namespaces to watch for LogInstances. If not
-                      provided, only checks own namespace.
                     properties:
                       matchExpressions:
-                        description: matchExpressions is a list of label selector
-                          requirements. The requirements are ANDed.
                         items:
-                          description: A label selector requirement is a selector
-                            that contains values, a key, and an operator that relates
-                            the key and values.
                           properties:
                             key:
-                              description: key is the label key that the selector
-                                applies to.
                               type: string
                             operator:
-                              description: operator represents a key's relationship
-                                to a set of values. Valid operators are In, NotIn,
-                                Exists and DoesNotExist.
                               type: string
                             values:
-                              description: values is an array of string values. If
-                                the operator is In or NotIn, the values array must
-                                be non-empty. If the operator is Exists or DoesNotExist,
-                                the values array must be empty. This array is replaced
-                                during a strategic merge patch.
                               items:
                                 type: string
                               type: array
@@ -4239,42 +2082,19 @@ spec:
                       matchLabels:
                         additionalProperties:
                           type: string
-                        description: matchLabels is a map of {key,value} pairs. A
-                          single {key,value} in the matchLabels map is equivalent
-                          to an element of matchExpressions, whose key field is "key",
-                          the operator is "In", and the values array contains only
-                          "value". The requirements are ANDed.
                         type: object
                     type: object
                     x-kubernetes-map-type: atomic
                   instanceSelector:
-                    description: InstanceSelector determines which LogInstances should
-                      be selected for running. Each instance runs its own set of Prometheus
-                      components, including service discovery, scraping, and remote_write.
                     properties:
                       matchExpressions:
-                        description: matchExpressions is a list of label selector
-                          requirements. The requirements are ANDed.
                         items:
-                          description: A label selector requirement is a selector
-                            that contains values, a key, and an operator that relates
-                            the key and values.
                           properties:
                             key:
-                              description: key is the label key that the selector
-                                applies to.
                               type: string
                             operator:
-                              description: operator represents a key's relationship
-                                to a set of values. Valid operators are In, NotIn,
-                                Exists and DoesNotExist.
                               type: string
                             values:
-                              description: values is an array of string values. If
-                                the operator is In or NotIn, the values array must
-                                be non-empty. If the operator is Exists or DoesNotExist,
-                                the values array must be empty. This array is replaced
-                                during a strategic merge patch.
                               items:
                                 type: string
                               type: array
@@ -4286,98 +2106,43 @@ spec:
                       matchLabels:
                         additionalProperties:
                           type: string
-                        description: matchLabels is a map of {key,value} pairs. A
-                          single {key,value} in the matchLabels map is equivalent
-                          to an element of matchExpressions, whose key field is "key",
-                          the operator is "In", and the values array contains only
-                          "value". The requirements are ANDed.
                         type: object
                     type: object
                     x-kubernetes-map-type: atomic
                   logsExternalLabelName:
-                    description: LogsExternalLabelName is the name of the external
-                      label used to denote Grafana Agent cluster. Defaults to "cluster."
-                      External label will _not_ be added when value is set to the
-                      empty string.
                     type: string
                 type: object
               metrics:
-                description: Metrics controls the metrics subsystem of the Agent and
-                  settings unique to metrics-specific pods that are deployed.
                 properties:
                   arbitraryFSAccessThroughSMs:
-                    description: ArbitraryFSAccessThroughSMs configures whether configuration
-                      based on a ServiceMonitor can access arbitrary files on the
-                      file system of the Grafana Agent container, e.g., bearer token
-                      files.
                     properties:
                       deny:
                         type: boolean
                     type: object
                   enforcedNamespaceLabel:
-                    description: EnforcedNamespaceLabel enforces adding a namespace
-                      label of origin for each metric that is user-created. The label
-                      value is always the namespace of the object that is being created.
                     type: string
                   enforcedSampleLimit:
-                    description: EnforcedSampleLimit defines a global limit on the
-                      number of scraped samples that are accepted. This overrides
-                      any SampleLimit set per ServiceMonitor and/or PodMonitor. It
-                      is meant to be used by admins to enforce the SampleLimit to
-                      keep the overall number of samples and series under the desired
-                      limit. Note that if a SampleLimit from a ServiceMonitor or PodMonitor
-                      is lower, that value is used instead.
                     format: int64
                     type: integer
                   enforcedTargetLimit:
-                    description: EnforcedTargetLimit defines a global limit on the
-                      number of scraped targets. This overrides any TargetLimit set
-                      per ServiceMonitor and/or PodMonitor. It is meant to be used
-                      by admins to enforce the TargetLimit to keep the overall number
-                      of targets under the desired limit. Note that if a TargetLimit
-                      from a ServiceMonitor or PodMonitor is higher, that value is
-                      used instead.
                     format: int64
                     type: integer
                   externalLabels:
                     additionalProperties:
                       type: string
-                    description: ExternalLabels are labels to add to any time series
-                      when sending data over remote_write.
                     type: object
                   ignoreNamespaceSelectors:
-                    description: IgnoreNamespaceSelectors, if true, ignores NamespaceSelector
-                      settings from the PodMonitor and ServiceMonitor configs, so
-                      that they only discover endpoints within their current namespace.
                     type: boolean
                   instanceNamespaceSelector:
-                    description: InstanceNamespaceSelector is the set of labels that
-                      determines which namespaces to watch for MetricsInstances. If
-                      not provided, it only checks its own namespace.
                     properties:
                       matchExpressions:
-                        description: matchExpressions is a list of label selector
-                          requirements. The requirements are ANDed.
                         items:
-                          description: A label selector requirement is a selector
-                            that contains values, a key, and an operator that relates
-                            the key and values.
                           properties:
                             key:
-                              description: key is the label key that the selector
-                                applies to.
                               type: string
                             operator:
-                              description: operator represents a key's relationship
-                                to a set of values. Valid operators are In, NotIn,
-                                Exists and DoesNotExist.
                               type: string
                             values:
-                              description: values is an array of string values. If
-                                the operator is In or NotIn, the values array must
-                                be non-empty. If the operator is Exists or DoesNotExist,
-                                the values array must be empty. This array is replaced
-                                during a strategic merge patch.
                               items:
                                 type: string
                               type: array
@@ -4389,43 +2154,19 @@ spec:
                       matchLabels:
                         additionalProperties:
                           type: string
-                        description: matchLabels is a map of {key,value} pairs. A
-                          single {key,value} in the matchLabels map is equivalent
-                          to an element of matchExpressions, whose key field is "key",
-                          the operator is "In", and the values array contains only
-                          "value". The requirements are ANDed.
                         type: object
                     type: object
                     x-kubernetes-map-type: atomic
                   instanceSelector:
-                    description: InstanceSelector determines which MetricsInstances
-                      should be selected for running. Each instance runs its own set
-                      of Metrics components, including service discovery, scraping,
-                      and remote_write.
                     properties:
                       matchExpressions:
-                        description: matchExpressions is a list of label selector
-                          requirements. The requirements are ANDed.
                         items:
-                          description: A label selector requirement is a selector
-                            that contains values, a key, and an operator that relates
-                            the key and values.
                           properties:
                             key:
-                              description: key is the label key that the selector
-                                applies to.
                               type: string
                             operator:
-                              description: operator represents a key's relationship
-                                to a set of values. Valid operators are In, NotIn,
-                                Exists and DoesNotExist.
                               type: string
                             values:
-                              description: values is an array of string values. If
-                                the operator is In or NotIn, the values array must
-                                be non-empty. If the operator is Exists or DoesNotExist,
-                                the values array must be empty. This array is replaced
-                                during a strategic merge patch.
                               items:
                                 type: string
                               type: array
@@ -4437,77 +2178,39 @@ spec:
                       matchLabels:
                         additionalProperties:
                           type: string
-                        description: matchLabels is a map of {key,value} pairs. A
-                          single {key,value} in the matchLabels map is equivalent
-                          to an element of matchExpressions, whose key field is "key",
-                          the operator is "In", and the values array contains only
-                          "value". The requirements are ANDed.
                         type: object
                     type: object
                     x-kubernetes-map-type: atomic
                   metricsExternalLabelName:
-                    description: MetricsExternalLabelName is the name of the external
-                      label used to denote Grafana Agent cluster. Defaults to "cluster."
-                      The external label is _not_ added when the value is set to the
-                      empty string.
                     type: string
                   overrideHonorLabels:
-                    description: OverrideHonorLabels, if true, overrides all configured
-                      honor_labels read from ServiceMonitor or PodMonitor and sets
-                      them to false.
                     type: boolean
                   overrideHonorTimestamps:
-                    description: OverrideHonorTimestamps allows global enforcement
-                      for honoring timestamps in all scrape configs.
                     type: boolean
                   remoteWrite:
-                    description: RemoteWrite controls default remote_write settings
-                      for all instances. If an instance does not provide its own RemoteWrite
-                      settings, these will be used instead.
                     items:
-                      description: RemoteWriteSpec defines the remote_write configuration
-                        for Prometheus.
                       properties:
                         basicAuth:
-                          description: BasicAuth for the URL.
                           properties:
                             password:
-                              description: The secret in the service monitor namespace
-                                that contains the password for authentication.
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must
-                                    be a valid secret key.
                                   type: string
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
-                                    must be defined
                                   type: boolean
                               required:
                               - key
                               type: object
                               x-kubernetes-map-type: atomic
                             username:
-                              description: The secret in the service monitor namespace
-                                that contains the username for authentication.
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must
-                                    be a valid secret key.
                                   type: string
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
-                                    must be defined
                                   type: boolean
                               required:
                               - key
@@ -4515,82 +2218,45 @@ spec:
                               x-kubernetes-map-type: atomic
                           type: object
                         bearerToken:
-                          description: BearerToken used for remote_write.
                           type: string
                         bearerTokenFile:
-                          description: BearerTokenFile used to read bearer token.
                           type: string
                         headers:
                           additionalProperties:
                             type: string
-                          description: Headers is a set of custom HTTP headers to
-                            be sent along with each remote_write request. Be aware
-                            that any headers set by Grafana Agent itself can't be
-                            overwritten.
                           type: object
                         metadataConfig:
-                          description: MetadataConfig configures the sending of series
-                            metadata to remote storage.
                           properties:
                             send:
-                              description: Send enables metric metadata to be sent
-                                to remote storage.
                               type: boolean
                             sendInterval:
-                              description: SendInterval controls how frequently metric
-                                metadata is sent to remote storage.
                               type: string
                           type: object
                         name:
-                          description: Name of the remote_write queue. Must be unique
-                            if specified. The name is used in metrics and logging
-                            in order to differentiate queues.
                           type: string
                         oauth2:
-                          description: Oauth2 for URL
                           properties:
                             clientId:
-                              description: The secret or configmap containing the
-                                OAuth2 client id
                               properties:
                                 configMap:
-                                  description: ConfigMap containing data to use for
-                                    the targets.
                                   properties:
                                     key:
-                                      description: The key to select.
                                       type: string
                                     name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
                                       type: string
                                     optional:
-                                      description: Specify whether the ConfigMap or
-                                        its key must be defined
                                       type: boolean
                                   required:
                                   - key
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 secret:
-                                  description: Secret containing data to use for the
-                                    targets.
                                   properties:
                                     key:
-                                      description: The key of the secret to select
-                                        from.  Must be a valid secret key.
                                       type: string
                                     name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
                                       type: string
                                     optional:
-                                      description: Specify whether the Secret or its
-                                        key must be defined
                                       type: boolean
                                   required:
                                   - key
@@ -4598,21 +2264,12 @@ spec:
                                   x-kubernetes-map-type: atomic
                               type: object
                             clientSecret:
-                              description: The secret containing the OAuth2 client
-                                secret
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must
-                                    be a valid secret key.
                                   type: string
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
-                                    must be defined
                                   type: boolean
                               required:
                               - key
@@ -4621,15 +2278,12 @@ spec:
                             endpointParams:
                               additionalProperties:
                                 type: string
-                              description: Parameters to append to the token URL
                               type: object
                             scopes:
-                              description: OAuth2 scopes used for the token request
                               items:
                                 type: string
                               type: array
                             tokenUrl:
-                              description: The URL to fetch the token from
                               minLength: 1
                               type: string
                           required:
@@ -4638,109 +2292,57 @@ spec:
                           - tokenUrl
                           type: object
                         proxyUrl:
-                          description: ProxyURL to proxy requests through. Optional.
                           type: string
                         queueConfig:
-                          description: QueueConfig allows tuning of the remote_write
-                            queue parameters.
                           properties:
                             batchSendDeadline:
-                              description: BatchSendDeadline is the maximum time a
-                                sample will wait in the buffer.
                               type: string
                             capacity:
-                              description: Capacity is the number of samples to buffer
-                                per shard before samples start being dropped.
                               type: integer
                             maxBackoff:
-                              description: MaxBackoff is the maximum retry delay.
                               type: string
                             maxRetries:
-                              description: MaxRetries is the maximum number of times
-                                to retry a batch on recoverable errors.
                               type: integer
                             maxSamplesPerSend:
-                              description: MaxSamplesPerSend is the maximum number
-                                of samples per send.
                               type: integer
                             maxShards:
-                              description: MaxShards is the maximum number of shards,
-                                i.e., the amount of concurrency.
                               type: integer
                             minBackoff:
-                              description: MinBackoff is the initial retry delay.
-                                MinBackoff is doubled for every retry.
                               type: string
                             minShards:
-                              description: MinShards is the minimum number of shards,
-                                i.e., the amount of concurrency.
                               type: integer
                             retryOnRateLimit:
-                              description: RetryOnRateLimit retries requests when
-                                encountering rate limits.
                               type: boolean
                           type: object
                         remoteTimeout:
-                          description: RemoteTimeout is the timeout for requests to
-                            the remote_write endpoint.
                           type: string
                         sigv4:
-                          description: SigV4 configures SigV4-based authentication
-                            to the remote_write endpoint. SigV4-based authentication
-                            is used if SigV4 is defined, even with an empty object.
                           properties:
                             accessKey:
-                              description: AccessKey holds the secret of the AWS API
-                                access key to use for signing. If not provided, the
-                                environment variable AWS_ACCESS_KEY_ID is used.
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must
-                                    be a valid secret key.
                                   type: string
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
-                                    must be defined
                                   type: boolean
                               required:
                               - key
                               type: object
                               x-kubernetes-map-type: atomic
                             profile:
-                              description: Profile is the named AWS profile to use
-                                for authentication.
                               type: string
                             region:
-                              description: Region of the AWS endpoint. If blank, the
-                                region from the default credentials chain is used.
                               type: string
                             roleARN:
-                              description: RoleARN is the AWS Role ARN to use for
-                                authentication, as an alternative for using the AWS
-                                API keys.
                               type: string
                             secretKey:
-                              description: SecretKey of the AWS API to use for signing.
-                                If blank, the environment variable AWS_SECRET_ACCESS_KEY
-                                is used.
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must
-                                    be a valid secret key.
                                   type: string
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
-                                    must be defined
                                   type: boolean
                               required:
                               - key
@@ -4748,50 +2350,28 @@ spec:
                               x-kubernetes-map-type: atomic
                           type: object
                         tlsConfig:
-                          description: TLSConfig to use for remote_write.
                           properties:
                             ca:
-                              description: Certificate authority used when verifying
-                                server certificates.
                               properties:
                                 configMap:
-                                  description: ConfigMap containing data to use for
-                                    the targets.
                                   properties:
                                     key:
-                                      description: The key to select.
                                       type: string
                                     name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
                                       type: string
                                     optional:
-                                      description: Specify whether the ConfigMap or
-                                        its key must be defined
                                       type: boolean
                                   required:
                                   - key
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 secret:
-                                  description: Secret containing data to use for the
-                                    targets.
                                   properties:
                                     key:
-                                      description: The key of the secret to select
-                                        from.  Must be a valid secret key.
                                       type: string
                                     name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
                                       type: string
                                     optional:
-                                      description: Specify whether the Secret or its
-                                        key must be defined
                                       type: boolean
                                   required:
                                   - key
@@ -4799,51 +2379,28 @@ spec:
                                   x-kubernetes-map-type: atomic
                               type: object
                             caFile:
-                              description: Path to the CA cert in the Prometheus container
-                                to use for the targets.
                               type: string
                             cert:
-                              description: Client certificate to present when doing
-                                client-authentication.
                               properties:
                                 configMap:
-                                  description: ConfigMap containing data to use for
-                                    the targets.
                                   properties:
                                     key:
-                                      description: The key to select.
                                       type: string
                                     name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
                                       type: string
                                     optional:
-                                      description: Specify whether the ConfigMap or
-                                        its key must be defined
                                       type: boolean
                                   required:
                                   - key
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 secret:
-                                  description: Secret containing data to use for the
-                                    targets.
                                   properties:
                                     key:
-                                      description: The key of the secret to select
-                                        from.  Must be a valid secret key.
                                       type: string
                                     name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
                                       type: string
                                     optional:
-                                      description: Specify whether the Secret or its
-                                        key must be defined
                                       type: boolean
                                   required:
                                   - key
@@ -4851,59 +2408,33 @@ spec:
                                   x-kubernetes-map-type: atomic
                               type: object
                             certFile:
-                              description: Path to the client cert file in the Prometheus
-                                container for the targets.
                               type: string
                             insecureSkipVerify:
-                              description: Disable target certificate validation.
                               type: boolean
                             keyFile:
-                              description: Path to the client key file in the Prometheus
-                                container for the targets.
                               type: string
                             keySecret:
-                              description: Secret containing the client key file for
-                                the targets.
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must
-                                    be a valid secret key.
                                   type: string
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
-                                    must be defined
                                   type: boolean
                               required:
                               - key
                               type: object
                               x-kubernetes-map-type: atomic
                             serverName:
-                              description: Used to verify the hostname for the targets.
                               type: string
                           type: object
                         url:
-                          description: URL of the endpoint to send samples to.
                           type: string
                         writeRelabelConfigs:
-                          description: WriteRelabelConfigs holds relabel_configs to
-                            relabel samples before they are sent to the remote_write
-                            endpoint.
                           items:
-                            description: 'RelabelConfig allows dynamic rewriting of
-                              the label set, being applied to samples before ingestion.
-                              It defines `<metric_relabel_configs>`-section of Prometheus
-                              configuration. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
                             properties:
                               action:
                                 default: replace
-                                description: Action to perform based on regex matching.
-                                  Default is 'replace'. uppercase and lowercase actions
-                                  require Prometheus >= 2.36.
                                 enum:
                                 - replace
                                 - Replace
@@ -4929,40 +2460,20 @@ spec:
                                 - DropEqual
                                 type: string
                               modulus:
-                                description: Modulus to take of the hash of the source
-                                  label values.
                                 format: int64
                                 type: integer
                               regex:
-                                description: Regular expression against which the
-                                  extracted value is matched. Default is '(.*)'
                                 type: string
                               replacement:
-                                description: Replacement value against which a regex
-                                  replace is performed if the regular expression matches.
-                                  Regex capture groups are available. Default is '$1'
                                 type: string
                               separator:
-                                description: Separator placed between concatenated
-                                  source label values. default is ';'.
                                 type: string
                               sourceLabels:
-                                description: The source labels select values from
-                                  existing labels. Their content is concatenated using
-                                  the configured separator and matched against the
-                                  configured regular expression for the replace, keep,
-                                  and drop actions.
                                 items:
-                                  description: LabelName is a valid Prometheus label
-                                    name which may only contain ASCII letters, numbers,
-                                    as well as underscores.
                                   pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
                                   type: string
                                 type: array
                               targetLabel:
-                                description: Label to which the resulting value is
-                                  written in a replace action. It is mandatory for
-                                  replace actions. Regex capture groups are available.
                                 type: string
                             type: object
                           type: array
@@ -4971,96 +2482,47 @@ spec:
                       type: object
                     type: array
                   replicaExternalLabelName:
-                    description: ReplicaExternalLabelName is the name of the metrics
-                      external label used to denote the replica name. Defaults to
-                      __replica__. The external label is _not_ added when the value
-                      is set to the empty string.
                     type: string
                   replicas:
-                    description: Replicas of each shard to deploy for metrics pods.
-                      Number of replicas multiplied by the number of shards is the
-                      total number of pods created.
                     format: int32
                     type: integer
                   scrapeInterval:
-                    description: ScrapeInterval is the time between consecutive scrapes.
                     type: string
                   scrapeTimeout:
-                    description: ScrapeTimeout is the time to wait for a target to
-                      respond before marking a scrape as failed.
                     type: string
                   shards:
-                    description: Shards to distribute targets onto. Number of replicas
-                      multiplied by the number of shards is the total number of pods
-                      created. Note that scaling down shards does not reshard data
-                      onto remaining instances; it must be manually moved. Increasing
-                      shards does not reshard data either, but it will continue to
-                      be available from the same instances. Sharding is performed
-                      on the content of the __address__ target meta-label.
                     format: int32
                     type: integer
                 type: object
               nodeSelector:
                 additionalProperties:
                   type: string
-                description: NodeSelector defines which nodes pods should be scheduling
-                  on.
                 type: object
               paused:
-                description: Paused prevents actions except for deletion to be performed
-                  on the underlying managed objects.
                 type: boolean
               podMetadata:
-                description: PodMetadata configures Labels and Annotations which are
-                  propagated to created Grafana Agent pods.
                 properties:
                   annotations:
                     additionalProperties:
                       type: string
-                    description: 'Annotations is an unstructured key value map stored
-                      with a resource that may be set by external tools to store and
-                      retrieve arbitrary metadata. They are not queryable and should
-                      be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
                     type: object
                   labels:
                     additionalProperties:
                       type: string
-                    description: 'Map of string keys and values that can be used to
-                      organize and categorize (scope and select) objects. May match
-                      selectors of replication controllers and services. More info:
-                      http://kubernetes.io/docs/user-guide/labels'
                     type: object
                   name:
-                    description: 'Name must be unique within a namespace. Is required
-                      when creating resources, although some resources may allow a
-                      client to request the generation of an appropriate name automatically.
-                      Name is primarily intended for creation idempotence and configuration
-                      definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
                     type: string
                 type: object
               portName:
-                description: Port name used for the pods and governing service. This
-                  defaults to agent-metrics.
                 type: string
               priorityClassName:
-                description: PriorityClassName is the priority class assigned to pods.
                 type: string
               resources:
-                description: Resources holds requests and limits for individual pods.
                 properties:
                   claims:
-                    description: "Claims lists the names of resources, defined in
-                      spec.resourceClaims, that are used by this container. \n This
-                      is an alpha field and requires enabling the DynamicResourceAllocation
-                      feature gate. \n This field is immutable. It can only be set
-                      for containers."
                     items:
-                      description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                       properties:
                         name:
-                          description: Name must match the name of one entry in pod.spec.resourceClaims
-                            of the Pod where this field is used. It makes that resource
-                            available inside a container.
                           type: string
                       required:
                       - name
@@ -5076,8 +2538,6 @@ spec:
                       - type: string
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
-                    description: 'Limits describes the maximum amount of compute resources
-                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                     type: object
                   requests:
                     additionalProperties:
@@ -5086,151 +2546,60 @@ spec:
                       - type: string
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
-                    description: 'Requests describes the minimum amount of compute
-                      resources required. If Requests is omitted for a container,
-                      it defaults to Limits if that is explicitly specified, otherwise
-                      to an implementation-defined value. Requests cannot exceed Limits.
-                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                     type: object
                 type: object
               runtimeClassName:
-                description: RuntimeClassName is the runtime class assigned to pods.
                 type: string
               secrets:
-                description: Secrets is a list of secrets in the same namespace as
-                  the GrafanaAgent object which will be mounted into each running
-                  Grafana Agent pod. The secrets are mounted into /var/lib/grafana-agent/extra-secrets/<secret-name>.
                 items:
                   type: string
                 type: array
               securityContext:
-                description: SecurityContext holds pod-level security attributes and
-                  common container settings. When unspecified, defaults to the default
-                  PodSecurityContext.
                 properties:
                   fsGroup:
-                    description: "A special supplemental group that applies to all
-                      containers in a pod. Some volume types allow the Kubelet to
-                      change the ownership of that volume to be owned by the pod:
-                      \n 1. The owning GID will be the FSGroup 2. The setgid bit is
-                      set (new files created in the volume will be owned by FSGroup)
-                      3. The permission bits are OR'd with rw-rw---- \n If unset,
-                      the Kubelet will not modify the ownership and permissions of
-                      any volume. Note that this field cannot be set when spec.os.name
-                      is windows."
                     format: int64
                     type: integer
                   fsGroupChangePolicy:
-                    description: 'fsGroupChangePolicy defines behavior of changing
-                      ownership and permission of the volume before being exposed
-                      inside Pod. This field will only apply to volume types which
-                      support fsGroup based ownership(and permissions). It will have
-                      no effect on ephemeral volume types such as: secret, configmaps
-                      and emptydir. Valid values are "OnRootMismatch" and "Always".
-                      If not specified, "Always" is used. Note that this field cannot
-                      be set when spec.os.name is windows.'
                     type: string
                   runAsGroup:
-                    description: The GID to run the entrypoint of the container process.
-                      Uses runtime default if unset. May also be set in SecurityContext.  If
-                      set in both SecurityContext and PodSecurityContext, the value
-                      specified in SecurityContext takes precedence for that container.
-                      Note that this field cannot be set when spec.os.name is windows.
                     format: int64
                     type: integer
                   runAsNonRoot:
-                    description: Indicates that the container must run as a non-root
-                      user. If true, the Kubelet will validate the image at runtime
-                      to ensure that it does not run as UID 0 (root) and fail to start
-                      the container if it does. If unset or false, no such validation
-                      will be performed. May also be set in SecurityContext.  If set
-                      in both SecurityContext and PodSecurityContext, the value specified
-                      in SecurityContext takes precedence.
                     type: boolean
                   runAsUser:
-                    description: The UID to run the entrypoint of the container process.
-                      Defaults to user specified in image metadata if unspecified.
-                      May also be set in SecurityContext.  If set in both SecurityContext
-                      and PodSecurityContext, the value specified in SecurityContext
-                      takes precedence for that container. Note that this field cannot
-                      be set when spec.os.name is windows.
                     format: int64
                     type: integer
                   seLinuxOptions:
-                    description: The SELinux context to be applied to all containers.
-                      If unspecified, the container runtime will allocate a random
-                      SELinux context for each container.  May also be set in SecurityContext.  If
-                      set in both SecurityContext and PodSecurityContext, the value
-                      specified in SecurityContext takes precedence for that container.
-                      Note that this field cannot be set when spec.os.name is windows.
                     properties:
                       level:
-                        description: Level is SELinux level label that applies to
-                          the container.
                         type: string
                       role:
-                        description: Role is a SELinux role label that applies to
-                          the container.
                         type: string
                       type:
-                        description: Type is a SELinux type label that applies to
-                          the container.
                         type: string
                       user:
-                        description: User is a SELinux user label that applies to
-                          the container.
                         type: string
                     type: object
                   seccompProfile:
-                    description: The seccomp options to use by the containers in this
-                      pod. Note that this field cannot be set when spec.os.name is
-                      windows.
                     properties:
                       localhostProfile:
-                        description: localhostProfile indicates a profile defined
-                          in a file on the node should be used. The profile must be
-                          preconfigured on the node to work. Must be a descending
-                          path, relative to the kubelet's configured seccomp profile
-                          location. Must be set if type is "Localhost". Must NOT be
-                          set for any other type.
                         type: string
                       type:
-                        description: "type indicates which kind of seccomp profile
-                          will be applied. Valid options are: \n Localhost - a profile
-                          defined in a file on the node should be used. RuntimeDefault
-                          - the container runtime default profile should be used.
-                          Unconfined - no profile should be applied."
                         type: string
                     required:
                     - type
                     type: object
                   supplementalGroups:
-                    description: A list of groups applied to the first process run
-                      in each container, in addition to the container's primary GID,
-                      the fsGroup (if specified), and group memberships defined in
-                      the container image for the uid of the container process. If
-                      unspecified, no additional groups are added to any container.
-                      Note that group memberships defined in the container image for
-                      the uid of the container process are still effective, even if
-                      they are not included in this list. Note that this field cannot
-                      be set when spec.os.name is windows.
                     items:
                       format: int64
                       type: integer
                     type: array
                   sysctls:
-                    description: Sysctls hold a list of namespaced sysctls used for
-                      the pod. Pods with unsupported sysctls (by the container runtime)
-                      might fail to launch. Note that this field cannot be set when
-                      spec.os.name is windows.
                     items:
-                      description: Sysctl defines a kernel parameter to be set
                       properties:
                         name:
-                          description: Name of a property to set
                           type: string
                         value:
-                          description: Value of a property to set
                           type: string
                       required:
                       - name
@@ -5238,146 +2607,53 @@ spec:
                       type: object
                     type: array
                   windowsOptions:
-                    description: The Windows specific settings applied to all containers.
-                      If unspecified, the options within a container's SecurityContext
-                      will be used. If set in both SecurityContext and PodSecurityContext,
-                      the value specified in SecurityContext takes precedence. Note
-                      that this field cannot be set when spec.os.name is linux.
                     properties:
                       gmsaCredentialSpec:
-                        description: GMSACredentialSpec is where the GMSA admission
-                          webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                          inlines the contents of the GMSA credential spec named by
-                          the GMSACredentialSpecName field.
                         type: string
                       gmsaCredentialSpecName:
-                        description: GMSACredentialSpecName is the name of the GMSA
-                          credential spec to use.
                         type: string
                       hostProcess:
-                        description: HostProcess determines if a container should
-                          be run as a 'Host Process' container. All of a Pod's containers
-                          must have the same effective HostProcess value (it is not
-                          allowed to have a mix of HostProcess containers and non-HostProcess
-                          containers). In addition, if HostProcess is true then HostNetwork
-                          must also be set to true.
                         type: boolean
                       runAsUserName:
-                        description: The UserName in Windows to run the entrypoint
-                          of the container process. Defaults to the user specified
-                          in image metadata if unspecified. May also be set in PodSecurityContext.
-                          If set in both SecurityContext and PodSecurityContext, the
-                          value specified in SecurityContext takes precedence.
                         type: string
                     type: object
                 type: object
               serviceAccountName:
-                description: ServiceAccountName is the name of the ServiceAccount
-                  to use for running Grafana Agent pods.
                 type: string
               storage:
-                description: Storage spec to specify how storage will be used.
                 properties:
                   disableMountSubPath:
-                    description: '*Deprecated: subPath usage will be removed in a
-                      future release.*'
                     type: boolean
                   emptyDir:
-                    description: 'EmptyDirVolumeSource to be used by the StatefulSet.
-                      If specified, it takes precedence over `ephemeral` and `volumeClaimTemplate`.
-                      More info: https://kubernetes.io/docs/concepts/storage/volumes/#emptydir'
                     properties:
                       medium:
-                        description: 'medium represents what type of storage medium
-                          should back this directory. The default is "" which means
-                          to use the node''s default medium. Must be an empty string
-                          (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                         type: string
                       sizeLimit:
                         anyOf:
                         - type: integer
                         - type: string
-                        description: 'sizeLimit is the total amount of local storage
-                          required for this EmptyDir volume. The size limit is also
-                          applicable for memory medium. The maximum usage on memory
-                          medium EmptyDir would be the minimum value between the SizeLimit
-                          specified here and the sum of memory limits of all containers
-                          in a pod. The default is nil which means that the limit
-                          is undefined. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                     type: object
                   ephemeral:
-                    description: 'EphemeralVolumeSource to be used by the StatefulSet.
-                      This is a beta field in k8s 1.21 and GA in 1.15. For lower versions,
-                      starting with k8s 1.19, it requires enabling the GenericEphemeralVolume
-                      feature gate. More info: https://kubernetes.io/docs/concepts/storage/ephemeral-volumes/#generic-ephemeral-volumes'
                     properties:
                       volumeClaimTemplate:
-                        description: "Will be used to create a stand-alone PVC to
-                          provision the volume. The pod in which this EphemeralVolumeSource
-                          is embedded will be the owner of the PVC, i.e. the PVC will
-                          be deleted together with the pod.  The name of the PVC will
-                          be `<pod name>-<volume name>` where `<volume name>` is the
-                          name from the `PodSpec.Volumes` array entry. Pod validation
-                          will reject the pod if the concatenated name is not valid
-                          for a PVC (for example, too long). \n An existing PVC with
-                          that name that is not owned by the pod will *not* be used
-                          for the pod to avoid using an unrelated volume by mistake.
-                          Starting the pod is then blocked until the unrelated PVC
-                          is removed. If such a pre-created PVC is meant to be used
-                          by the pod, the PVC has to updated with an owner reference
-                          to the pod once the pod exists. Normally this should not
-                          be necessary, but it may be useful when manually reconstructing
-                          a broken cluster. \n This field is read-only and no changes
-                          will be made by Kubernetes to the PVC after it has been
-                          created. \n Required, must not be nil."
                         properties:
                           metadata:
-                            description: May contain labels and annotations that will
-                              be copied into the PVC when creating it. No other fields
-                              are allowed and will be rejected during validation.
                             type: object
                           spec:
-                            description: The specification for the PersistentVolumeClaim.
-                              The entire content is copied unchanged into the PVC
-                              that gets created from this template. The same fields
-                              as in a PersistentVolumeClaim are also valid here.
                             properties:
                               accessModes:
-                                description: 'accessModes contains the desired access
-                                  modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                                 items:
                                   type: string
                                 type: array
                               dataSource:
-                                description: 'dataSource field can be used to specify
-                                  either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                                  * An existing PVC (PersistentVolumeClaim) If the
-                                  provisioner or an external controller can support
-                                  the specified data source, it will create a new
-                                  volume based on the contents of the specified data
-                                  source. When the AnyVolumeDataSource feature gate
-                                  is enabled, dataSource contents will be copied to
-                                  dataSourceRef, and dataSourceRef contents will be
-                                  copied to dataSource when dataSourceRef.namespace
-                                  is not specified. If the namespace is specified,
-                                  then dataSourceRef will not be copied to dataSource.'
                                 properties:
                                   apiGroup:
-                                    description: APIGroup is the group for the resource
-                                      being referenced. If APIGroup is not specified,
-                                      the specified Kind must be in the core API group.
-                                      For any other third-party types, APIGroup is
-                                      required.
                                     type: string
                                   kind:
-                                    description: Kind is the type of resource being
-                                      referenced
                                     type: string
                                   name:
-                                    description: Name is the name of resource being
-                                      referenced
                                     type: string
                                 required:
                                 - kind
@@ -5385,90 +2661,25 @@ spec:
                                 type: object
                                 x-kubernetes-map-type: atomic
                               dataSourceRef:
-                                description: 'dataSourceRef specifies the object from
-                                  which to populate the volume with data, if a non-empty
-                                  volume is desired. This may be any object from a
-                                  non-empty API group (non core object) or a PersistentVolumeClaim
-                                  object. When this field is specified, volume binding
-                                  will only succeed if the type of the specified object
-                                  matches some installed volume populator or dynamic
-                                  provisioner. This field will replace the functionality
-                                  of the dataSource field and as such if both fields
-                                  are non-empty, they must have the same value. For
-                                  backwards compatibility, when namespace isn''t specified
-                                  in dataSourceRef, both fields (dataSource and dataSourceRef)
-                                  will be set to the same value automatically if one
-                                  of them is empty and the other is non-empty. When
-                                  namespace is specified in dataSourceRef, dataSource
-                                  isn''t set to the same value and must be empty.
-                                  There are three important differences between dataSource
-                                  and dataSourceRef: * While dataSource only allows
-                                  two specific types of objects, dataSourceRef allows
-                                  any non-core object, as well as PersistentVolumeClaim
-                                  objects. * While dataSource ignores disallowed values
-                                  (dropping them), dataSourceRef preserves all values,
-                                  and generates an error if a disallowed value is
-                                  specified. * While dataSource only allows local
-                                  objects, dataSourceRef allows objects in any namespaces.
-                                  (Beta) Using this field requires the AnyVolumeDataSource
-                                  feature gate to be enabled. (Alpha) Using the namespace
-                                  field of dataSourceRef requires the CrossNamespaceVolumeDataSource
-                                  feature gate to be enabled.'
                                 properties:
                                   apiGroup:
-                                    description: APIGroup is the group for the resource
-                                      being referenced. If APIGroup is not specified,
-                                      the specified Kind must be in the core API group.
-                                      For any other third-party types, APIGroup is
-                                      required.
                                     type: string
                                   kind:
-                                    description: Kind is the type of resource being
-                                      referenced
                                     type: string
                                   name:
-                                    description: Name is the name of resource being
-                                      referenced
                                     type: string
                                   namespace:
-                                    description: Namespace is the namespace of resource
-                                      being referenced Note that when a namespace
-                                      is specified, a gateway.networking.k8s.io/ReferenceGrant
-                                      object is required in the referent namespace
-                                      to allow that namespace's owner to accept the
-                                      reference. See the ReferenceGrant documentation
-                                      for details. (Alpha) This field requires the
-                                      CrossNamespaceVolumeDataSource feature gate
-                                      to be enabled.
                                     type: string
                                 required:
                                 - kind
                                 - name
                                 type: object
                               resources:
-                                description: 'resources represents the minimum resources
-                                  the volume should have. If RecoverVolumeExpansionFailure
-                                  feature is enabled users are allowed to specify
-                                  resource requirements that are lower than previous
-                                  value but must still be higher than capacity recorded
-                                  in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                                 properties:
                                   claims:
-                                    description: "Claims lists the names of resources,
-                                      defined in spec.resourceClaims, that are used
-                                      by this container. \n This is an alpha field
-                                      and requires enabling the DynamicResourceAllocation
-                                      feature gate. \n This field is immutable. It
-                                      can only be set for containers."
                                     items:
-                                      description: ResourceClaim references one entry
-                                        in PodSpec.ResourceClaims.
                                       properties:
                                         name:
-                                          description: Name must match the name of
-                                            one entry in pod.spec.resourceClaims of
-                                            the Pod where this field is used. It makes
-                                            that resource available inside a container.
                                           type: string
                                       required:
                                       - name
@@ -5484,8 +2695,6 @@ spec:
                                       - type: string
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
-                                    description: 'Limits describes the maximum amount
-                                      of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                     type: object
                                   requests:
                                     additionalProperties:
@@ -5494,43 +2703,18 @@ spec:
                                       - type: string
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
-                                    description: 'Requests describes the minimum amount
-                                      of compute resources required. If Requests is
-                                      omitted for a container, it defaults to Limits
-                                      if that is explicitly specified, otherwise to
-                                      an implementation-defined value. Requests cannot
-                                      exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                     type: object
                                 type: object
                               selector:
-                                description: selector is a label query over volumes
-                                  to consider for binding.
                                 properties:
                                   matchExpressions:
-                                    description: matchExpressions is a list of label
-                                      selector requirements. The requirements are
-                                      ANDed.
                                     items:
-                                      description: A label selector requirement is
-                                        a selector that contains values, a key, and
-                                        an operator that relates the key and values.
                                       properties:
                                         key:
-                                          description: key is the label key that the
-                                            selector applies to.
                                           type: string
                                         operator:
-                                          description: operator represents a key's
-                                            relationship to a set of values. Valid
-                                            operators are In, NotIn, Exists and DoesNotExist.
                                           type: string
                                         values:
-                                          description: values is an array of string
-                                            values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If
-                                            the operator is Exists or DoesNotExist,
-                                            the values array must be empty. This array
-                                            is replaced during a strategic merge patch.
                                           items:
                                             type: string
                                           type: array
@@ -5542,27 +2726,14 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description: matchLabels is a map of {key,value}
-                                      pairs. A single {key,value} in the matchLabels
-                                      map is equivalent to an element of matchExpressions,
-                                      whose key field is "key", the operator is "In",
-                                      and the values array contains only "value".
-                                      The requirements are ANDed.
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
                               storageClassName:
-                                description: 'storageClassName is the name of the
-                                  StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                                 type: string
                               volumeMode:
-                                description: volumeMode defines what type of volume
-                                  is required by the claim. Value of Filesystem is
-                                  implied when not included in claim spec.
                                 type: string
                               volumeName:
-                                description: volumeName is the binding reference to
-                                  the PersistentVolume backing this claim.
                                 type: string
                             type: object
                         required:
@@ -5570,87 +2741,37 @@ spec:
                         type: object
                     type: object
                   volumeClaimTemplate:
-                    description: Defines the PVC spec to be used by the Prometheus
-                      StatefulSets. The easiest way to use a volume that cannot be
-                      automatically provisioned is to use a label selector alongside
-                      manually created PersistentVolumes.
                     properties:
                       apiVersion:
-                        description: 'APIVersion defines the versioned schema of this
-                          representation of an object. Servers should convert recognized
-                          schemas to the latest internal value, and may reject unrecognized
-                          values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
                         type: string
                       kind:
-                        description: 'Kind is a string value representing the REST
-                          resource this object represents. Servers may infer this
-                          from the endpoint the client submits requests to. Cannot
-                          be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                         type: string
                       metadata:
-                        description: EmbeddedMetadata contains metadata relevant to
-                          an EmbeddedResource.
                         properties:
                           annotations:
                             additionalProperties:
                               type: string
-                            description: 'Annotations is an unstructured key value
-                              map stored with a resource that may be set by external
-                              tools to store and retrieve arbitrary metadata. They
-                              are not queryable and should be preserved when modifying
-                              objects. More info: http://kubernetes.io/docs/user-guide/annotations'
                             type: object
                           labels:
                             additionalProperties:
                               type: string
-                            description: 'Map of string keys and values that can be
-                              used to organize and categorize (scope and select) objects.
-                              May match selectors of replication controllers and services.
-                              More info: http://kubernetes.io/docs/user-guide/labels'
                             type: object
                           name:
-                            description: 'Name must be unique within a namespace.
-                              Is required when creating resources, although some resources
-                              may allow a client to request the generation of an appropriate
-                              name automatically. Name is primarily intended for creation
-                              idempotence and configuration definition. Cannot be
-                              updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
                             type: string
                         type: object
                       spec:
-                        description: 'Defines the desired characteristics of a volume
-                          requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                         properties:
                           accessModes:
-                            description: 'accessModes contains the desired access
-                              modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                             items:
                               type: string
                             type: array
                           dataSource:
-                            description: 'dataSource field can be used to specify
-                              either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                              * An existing PVC (PersistentVolumeClaim) If the provisioner
-                              or an external controller can support the specified
-                              data source, it will create a new volume based on the
-                              contents of the specified data source. When the AnyVolumeDataSource
-                              feature gate is enabled, dataSource contents will be
-                              copied to dataSourceRef, and dataSourceRef contents
-                              will be copied to dataSource when dataSourceRef.namespace
-                              is not specified. If the namespace is specified, then
-                              dataSourceRef will not be copied to dataSource.'
                             properties:
                               apiGroup:
-                                description: APIGroup is the group for the resource
-                                  being referenced. If APIGroup is not specified,
-                                  the specified Kind must be in the core API group.
-                                  For any other third-party types, APIGroup is required.
                                 type: string
                               kind:
-                                description: Kind is the type of resource being referenced
                                 type: string
                               name:
-                                description: Name is the name of resource being referenced
                                 type: string
                             required:
                             - kind
@@ -5658,85 +2779,25 @@ spec:
                             type: object
                             x-kubernetes-map-type: atomic
                           dataSourceRef:
-                            description: 'dataSourceRef specifies the object from
-                              which to populate the volume with data, if a non-empty
-                              volume is desired. This may be any object from a non-empty
-                              API group (non core object) or a PersistentVolumeClaim
-                              object. When this field is specified, volume binding
-                              will only succeed if the type of the specified object
-                              matches some installed volume populator or dynamic provisioner.
-                              This field will replace the functionality of the dataSource
-                              field and as such if both fields are non-empty, they
-                              must have the same value. For backwards compatibility,
-                              when namespace isn''t specified in dataSourceRef, both
-                              fields (dataSource and dataSourceRef) will be set to
-                              the same value automatically if one of them is empty
-                              and the other is non-empty. When namespace is specified
-                              in dataSourceRef, dataSource isn''t set to the same
-                              value and must be empty. There are three important differences
-                              between dataSource and dataSourceRef: * While dataSource
-                              only allows two specific types of objects, dataSourceRef
-                              allows any non-core object, as well as PersistentVolumeClaim
-                              objects. * While dataSource ignores disallowed values
-                              (dropping them), dataSourceRef preserves all values,
-                              and generates an error if a disallowed value is specified.
-                              * While dataSource only allows local objects, dataSourceRef
-                              allows objects in any namespaces. (Beta) Using this
-                              field requires the AnyVolumeDataSource feature gate
-                              to be enabled. (Alpha) Using the namespace field of
-                              dataSourceRef requires the CrossNamespaceVolumeDataSource
-                              feature gate to be enabled.'
                             properties:
                               apiGroup:
-                                description: APIGroup is the group for the resource
-                                  being referenced. If APIGroup is not specified,
-                                  the specified Kind must be in the core API group.
-                                  For any other third-party types, APIGroup is required.
                                 type: string
                               kind:
-                                description: Kind is the type of resource being referenced
                                 type: string
                               name:
-                                description: Name is the name of resource being referenced
                                 type: string
                               namespace:
-                                description: Namespace is the namespace of resource
-                                  being referenced Note that when a namespace is specified,
-                                  a gateway.networking.k8s.io/ReferenceGrant object
-                                  is required in the referent namespace to allow that
-                                  namespace's owner to accept the reference. See the
-                                  ReferenceGrant documentation for details. (Alpha)
-                                  This field requires the CrossNamespaceVolumeDataSource
-                                  feature gate to be enabled.
                                 type: string
                             required:
                             - kind
                             - name
                             type: object
                           resources:
-                            description: 'resources represents the minimum resources
-                              the volume should have. If RecoverVolumeExpansionFailure
-                              feature is enabled users are allowed to specify resource
-                              requirements that are lower than previous value but
-                              must still be higher than capacity recorded in the status
-                              field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                             properties:
                               claims:
-                                description: "Claims lists the names of resources,
-                                  defined in spec.resourceClaims, that are used by
-                                  this container. \n This is an alpha field and requires
-                                  enabling the DynamicResourceAllocation feature gate.
-                                  \n This field is immutable. It can only be set for
-                                  containers."
                                 items:
-                                  description: ResourceClaim references one entry
-                                    in PodSpec.ResourceClaims.
                                   properties:
                                     name:
-                                      description: Name must match the name of one
-                                        entry in pod.spec.resourceClaims of the Pod
-                                        where this field is used. It makes that resource
-                                        available inside a container.
                                       type: string
                                   required:
                                   - name
@@ -5752,8 +2813,6 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: 'Limits describes the maximum amount
-                                  of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                 type: object
                               requests:
                                 additionalProperties:
@@ -5762,42 +2821,18 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: 'Requests describes the minimum amount
-                                  of compute resources required. If Requests is omitted
-                                  for a container, it defaults to Limits if that is
-                                  explicitly specified, otherwise to an implementation-defined
-                                  value. Requests cannot exceed Limits. More info:
-                                  https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                 type: object
                             type: object
                           selector:
-                            description: selector is a label query over volumes to
-                              consider for binding.
                             properties:
                               matchExpressions:
-                                description: matchExpressions is a list of label selector
-                                  requirements. The requirements are ANDed.
                                 items:
-                                  description: A label selector requirement is a selector
-                                    that contains values, a key, and an operator that
-                                    relates the key and values.
                                   properties:
                                     key:
-                                      description: key is the label key that the selector
-                                        applies to.
                                       type: string
                                     operator:
-                                      description: operator represents a key's relationship
-                                        to a set of values. Valid operators are In,
-                                        NotIn, Exists and DoesNotExist.
                                       type: string
                                     values:
-                                      description: values is an array of string values.
-                                        If the operator is In or NotIn, the values
-                                        array must be non-empty. If the operator is
-                                        Exists or DoesNotExist, the values array must
-                                        be empty. This array is replaced during a
-                                        strategic merge patch.
                                       items:
                                         type: string
                                       type: array
@@ -5809,80 +2844,25 @@ spec:
                               matchLabels:
                                 additionalProperties:
                                   type: string
-                                description: matchLabels is a map of {key,value} pairs.
-                                  A single {key,value} in the matchLabels map is equivalent
-                                  to an element of matchExpressions, whose key field
-                                  is "key", the operator is "In", and the values array
-                                  contains only "value". The requirements are ANDed.
                                 type: object
                             type: object
                             x-kubernetes-map-type: atomic
                           storageClassName:
-                            description: 'storageClassName is the name of the StorageClass
-                              required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                             type: string
                           volumeMode:
-                            description: volumeMode defines what type of volume is
-                              required by the claim. Value of Filesystem is implied
-                              when not included in claim spec.
                             type: string
                           volumeName:
-                            description: volumeName is the binding reference to the
-                              PersistentVolume backing this claim.
                             type: string
                         type: object
                       status:
-                        description: '*Deprecated: this field is never set.*'
                         properties:
                           accessModes:
-                            description: 'accessModes contains the actual access modes
-                              the volume backing the PVC has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                             items:
                               type: string
                             type: array
                           allocatedResourceStatuses:
                             additionalProperties:
-                              description: When a controller receives persistentvolume
-                                claim update with ClaimResourceStatus for a resource
-                                that it does not recognizes, then it should ignore
-                                that update and let other controllers handle it.
                               type: string
-                            description: "allocatedResourceStatuses stores status
-                              of resource being resized for the given PVC. Key names
-                              follow standard Kubernetes label syntax. Valid values
-                              are either: * Un-prefixed keys: - storage - the capacity
-                              of the volume. * Custom resources must use implementation-defined
-                              prefixed names such as \"example.com/my-custom-resource\"
-                              Apart from above values - keys that are unprefixed or
-                              have kubernetes.io prefix are considered reserved and
-                              hence may not be used. \n ClaimResourceStatus can be
-                              in any of following states: - ControllerResizeInProgress:
-                              State set when resize controller starts resizing the
-                              volume in control-plane. - ControllerResizeFailed: State
-                              set when resize has failed in resize controller with
-                              a terminal error. - NodeResizePending: State set when
-                              resize controller has finished resizing the volume but
-                              further resizing of volume is needed on the node. -
-                              NodeResizeInProgress: State set when kubelet starts
-                              resizing the volume. - NodeResizeFailed: State set when
-                              resizing has failed in kubelet with a terminal error.
-                              Transient errors don't set NodeResizeFailed. For example:
-                              if expanding a PVC for more capacity - this field can
-                              be one of the following states: - pvc.status.allocatedResourceStatus['storage']
-                              = \"ControllerResizeInProgress\" - pvc.status.allocatedResourceStatus['storage']
-                              = \"ControllerResizeFailed\" - pvc.status.allocatedResourceStatus['storage']
-                              = \"NodeResizePending\" - pvc.status.allocatedResourceStatus['storage']
-                              = \"NodeResizeInProgress\" - pvc.status.allocatedResourceStatus['storage']
-                              = \"NodeResizeFailed\" When this field is not set, it
-                              means that no resize operation is in progress for the
-                              given PVC. \n A controller that receives PVC update
-                              with previously unknown resourceName or ClaimResourceStatus
-                              should ignore the update for the purpose it was designed.
-                              For example - a controller that only is responsible
-                              for resizing capacity of the volume, should ignore PVC
-                              updates that change other valid resources associated
-                              with PVC. \n This is an alpha field and requires enabling
-                              RecoverVolumeExpansionFailure feature."
                             type: object
                             x-kubernetes-map-type: granular
                           allocatedResources:
@@ -5892,31 +2872,6 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: "allocatedResources tracks the resources
-                              allocated to a PVC including its capacity. Key names
-                              follow standard Kubernetes label syntax. Valid values
-                              are either: * Un-prefixed keys: - storage - the capacity
-                              of the volume. * Custom resources must use implementation-defined
-                              prefixed names such as \"example.com/my-custom-resource\"
-                              Apart from above values - keys that are unprefixed or
-                              have kubernetes.io prefix are considered reserved and
-                              hence may not be used. \n Capacity reported here may
-                              be larger than the actual capacity when a volume expansion
-                              operation is requested. For storage quota, the larger
-                              value from allocatedResources and PVC.spec.resources
-                              is used. If allocatedResources is not set, PVC.spec.resources
-                              alone is used for quota calculation. If a volume expansion
-                              capacity request is lowered, allocatedResources is only
-                              lowered if there are no expansion operations in progress
-                              and if the actual volume capacity is equal or lower
-                              than the requested capacity. \n A controller that receives
-                              PVC update with previously unknown resourceName should
-                              ignore the update for the purpose it was designed. For
-                              example - a controller that only is responsible for
-                              resizing capacity of the volume, should ignore PVC updates
-                              that change other valid resources associated with PVC.
-                              \n This is an alpha field and requires enabling RecoverVolumeExpansionFailure
-                              feature."
                             type: object
                           capacity:
                             additionalProperties:
@@ -5925,43 +2880,23 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: capacity represents the actual resources
-                              of the underlying volume.
                             type: object
                           conditions:
-                            description: conditions is the current Condition of persistent
-                              volume claim. If underlying persistent volume is being
-                              resized then the Condition will be set to 'ResizeStarted'.
                             items:
-                              description: PersistentVolumeClaimCondition contains
-                                details about state of pvc
                               properties:
                                 lastProbeTime:
-                                  description: lastProbeTime is the time we probed
-                                    the condition.
                                   format: date-time
                                   type: string
                                 lastTransitionTime:
-                                  description: lastTransitionTime is the time the
-                                    condition transitioned from one status to another.
                                   format: date-time
                                   type: string
                                 message:
-                                  description: message is the human-readable message
-                                    indicating details about last transition.
                                   type: string
                                 reason:
-                                  description: reason is a unique, this should be
-                                    a short, machine understandable string that gives
-                                    the reason for condition's last transition. If
-                                    it reports "ResizeStarted" that means the underlying
-                                    persistent volume is being resized.
                                   type: string
                                 status:
                                   type: string
                                 type:
-                                  description: PersistentVolumeClaimConditionType
-                                    is a valid value of PersistentVolumeClaimCondition.Type
                                   type: string
                               required:
                               - status
@@ -5969,86 +2904,39 @@ spec:
                               type: object
                             type: array
                           phase:
-                            description: phase represents the current phase of PersistentVolumeClaim.
                             type: string
                         type: object
                     type: object
                 type: object
               tolerations:
-                description: Tolerations, if specified, controls the pod's tolerations.
                 items:
-                  description: The pod this Toleration is attached to tolerates any
-                    taint that matches the triple <key,value,effect> using the matching
-                    operator <operator>.
                   properties:
                     effect:
-                      description: Effect indicates the taint effect to match. Empty
-                        means match all taint effects. When specified, allowed values
-                        are NoSchedule, PreferNoSchedule and NoExecute.
                       type: string
                     key:
-                      description: Key is the taint key that the toleration applies
-                        to. Empty means match all taint keys. If the key is empty,
-                        operator must be Exists; this combination means to match all
-                        values and all keys.
                       type: string
                     operator:
-                      description: Operator represents a key's relationship to the
-                        value. Valid operators are Exists and Equal. Defaults to Equal.
-                        Exists is equivalent to wildcard for value, so that a pod
-                        can tolerate all taints of a particular category.
                       type: string
                     tolerationSeconds:
-                      description: TolerationSeconds represents the period of time
-                        the toleration (which must be of effect NoExecute, otherwise
-                        this field is ignored) tolerates the taint. By default, it
-                        is not set, which means tolerate the taint forever (do not
-                        evict). Zero and negative values will be treated as 0 (evict
-                        immediately) by the system.
                       format: int64
                       type: integer
                     value:
-                      description: Value is the taint value the toleration matches
-                        to. If the operator is Exists, the value should be empty,
-                        otherwise just a regular string.
                       type: string
                   type: object
                 type: array
               topologySpreadConstraints:
-                description: TopologySpreadConstraints, if specified, controls the
-                  pod's topology spread constraints.
                 items:
-                  description: TopologySpreadConstraint specifies how to spread matching
-                    pods among the given topology.
                   properties:
                     labelSelector:
-                      description: LabelSelector is used to find matching pods. Pods
-                        that match this label selector are counted to determine the
-                        number of pods in their corresponding topology domain.
                       properties:
                         matchExpressions:
-                          description: matchExpressions is a list of label selector
-                            requirements. The requirements are ANDed.
                           items:
-                            description: A label selector requirement is a selector
-                              that contains values, a key, and an operator that relates
-                              the key and values.
                             properties:
                               key:
-                                description: key is the label key that the selector
-                                  applies to.
                                 type: string
                               operator:
-                                description: operator represents a key's relationship
-                                  to a set of values. Valid operators are In, NotIn,
-                                  Exists and DoesNotExist.
                                 type: string
                               values:
-                                description: values is an array of string values.
-                                  If the operator is In or NotIn, the values array
-                                  must be non-empty. If the operator is Exists or
-                                  DoesNotExist, the values array must be empty. This
-                                  array is replaced during a strategic merge patch.
                                 items:
                                   type: string
                                 type: array
@@ -6060,126 +2948,27 @@ spec:
                         matchLabels:
                           additionalProperties:
                             type: string
-                          description: matchLabels is a map of {key,value} pairs.
-                            A single {key,value} in the matchLabels map is equivalent
-                            to an element of matchExpressions, whose key field is
-                            "key", the operator is "In", and the values array contains
-                            only "value". The requirements are ANDed.
                           type: object
                       type: object
                       x-kubernetes-map-type: atomic
                     matchLabelKeys:
-                      description: "MatchLabelKeys is a set of pod label keys to select
-                        the pods over which spreading will be calculated. The keys
-                        are used to lookup values from the incoming pod labels, those
-                        key-value labels are ANDed with labelSelector to select the
-                        group of existing pods over which spreading will be calculated
-                        for the incoming pod. The same key is forbidden to exist in
-                        both MatchLabelKeys and LabelSelector. MatchLabelKeys cannot
-                        be set when LabelSelector isn't set. Keys that don't exist
-                        in the incoming pod labels will be ignored. A null or empty
-                        list means only match against labelSelector. \n This is a
-                        beta field and requires the MatchLabelKeysInPodTopologySpread
-                        feature gate to be enabled (enabled by default)."
                       items:
                         type: string
                       type: array
                       x-kubernetes-list-type: atomic
                     maxSkew:
-                      description: 'MaxSkew describes the degree to which pods may
-                        be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
-                        it is the maximum permitted difference between the number
-                        of matching pods in the target topology and the global minimum.
-                        The global minimum is the minimum number of matching pods
-                        in an eligible domain or zero if the number of eligible domains
-                        is less than MinDomains. For example, in a 3-zone cluster,
-                        MaxSkew is set to 1, and pods with the same labelSelector
-                        spread as 2/2/1: In this case, the global minimum is 1. |
-                        zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | - if MaxSkew
-                        is 1, incoming pod can only be scheduled to zone3 to become
-                        2/2/2; scheduling it onto zone1(zone2) would make the ActualSkew(3-1)
-                        on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming
-                        pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`,
-                        it is used to give higher precedence to topologies that satisfy
-                        it. It''s a required field. Default value is 1 and 0 is not
-                        allowed.'
                       format: int32
                       type: integer
                     minDomains:
-                      description: "MinDomains indicates a minimum number of eligible
-                        domains. When the number of eligible domains with matching
-                        topology keys is less than minDomains, Pod Topology Spread
-                        treats \"global minimum\" as 0, and then the calculation of
-                        Skew is performed. And when the number of eligible domains
-                        with matching topology keys equals or greater than minDomains,
-                        this value has no effect on scheduling. As a result, when
-                        the number of eligible domains is less than minDomains, scheduler
-                        won't schedule more than maxSkew Pods to those domains. If
-                        value is nil, the constraint behaves as if MinDomains is equal
-                        to 1. Valid values are integers greater than 0. When value
-                        is not nil, WhenUnsatisfiable must be DoNotSchedule. \n For
-                        example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains
-                        is set to 5 and pods with the same labelSelector spread as
-                        2/2/2: | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  |
-                        The number of domains is less than 5(MinDomains), so \"global
-                        minimum\" is treated as 0. In this situation, new pod with
-                        the same labelSelector cannot be scheduled, because computed
-                        skew will be 3(3 - 0) if new Pod is scheduled to any of the
-                        three zones, it will violate MaxSkew. \n This is a beta field
-                        and requires the MinDomainsInPodTopologySpread feature gate
-                        to be enabled (enabled by default)."
                       format: int32
                       type: integer
                     nodeAffinityPolicy:
-                      description: "NodeAffinityPolicy indicates how we will treat
-                        Pod's nodeAffinity/nodeSelector when calculating pod topology
-                        spread skew. Options are: - Honor: only nodes matching nodeAffinity/nodeSelector
-                        are included in the calculations. - Ignore: nodeAffinity/nodeSelector
-                        are ignored. All nodes are included in the calculations. \n
-                        If this value is nil, the behavior is equivalent to the Honor
-                        policy. This is a beta-level feature default enabled by the
-                        NodeInclusionPolicyInPodTopologySpread feature flag."
                       type: string
                     nodeTaintsPolicy:
-                      description: "NodeTaintsPolicy indicates how we will treat node
-                        taints when calculating pod topology spread skew. Options
-                        are: - Honor: nodes without taints, along with tainted nodes
-                        for which the incoming pod has a toleration, are included.
-                        - Ignore: node taints are ignored. All nodes are included.
-                        \n If this value is nil, the behavior is equivalent to the
-                        Ignore policy. This is a beta-level feature default enabled
-                        by the NodeInclusionPolicyInPodTopologySpread feature flag."
                       type: string
                     topologyKey:
-                      description: TopologyKey is the key of node labels. Nodes that
-                        have a label with this key and identical values are considered
-                        to be in the same topology. We consider each <key, value>
-                        as a "bucket", and try to put balanced number of pods into
-                        each bucket. We define a domain as a particular instance of
-                        a topology. Also, we define an eligible domain as a domain
-                        whose nodes meet the requirements of nodeAffinityPolicy and
-                        nodeTaintsPolicy. e.g. If TopologyKey is "kubernetes.io/hostname",
-                        each Node is a domain of that topology. And, if TopologyKey
-                        is "topology.kubernetes.io/zone", each zone is a domain of
-                        that topology. It's a required field.
                       type: string
                     whenUnsatisfiable:
-                      description: 'WhenUnsatisfiable indicates how to deal with a
-                        pod if it doesn''t satisfy the spread constraint. - DoNotSchedule
-                        (default) tells the scheduler not to schedule it. - ScheduleAnyway
-                        tells the scheduler to schedule the pod in any location, but
-                        giving higher precedence to topologies that would help reduce
-                        the skew. A constraint is considered "Unsatisfiable" for an
-                        incoming pod if and only if every possible node assignment
-                        for that pod would violate "MaxSkew" on some topology. For
-                        example, in a 3-zone cluster, MaxSkew is set to 1, and pods
-                        with the same labelSelector spread as 3/1/1: | zone1 | zone2
-                        | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is
-                        set to DoNotSchedule, incoming pod can only be scheduled to
-                        zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on
-                        zone2(zone3) satisfies MaxSkew(1). In other words, the cluster
-                        can still be imbalanced, but scheduler won''t make it *more*
-                        imbalanced. It''s a required field.'
                       type: string
                   required:
                   - maxSkew
@@ -6188,44 +2977,21 @@ spec:
                   type: object
                 type: array
               version:
-                description: Version of Grafana Agent to be deployed.
                 type: string
               volumeMounts:
-                description: VolumeMounts lets you configure additional VolumeMounts
-                  on the output StatefulSet definition. Specified VolumeMounts are
-                  appended to other VolumeMounts generated as a result of StorageSpec
-                  objects in the Grafana Agent container.
                 items:
-                  description: VolumeMount describes a mounting of a Volume within
-                    a container.
                   properties:
                     mountPath:
-                      description: Path within the container at which the volume should
-                        be mounted.  Must not contain ':'.
                       type: string
                     mountPropagation:
-                      description: mountPropagation determines how mounts are propagated
-                        from the host to container and the other way around. When
-                        not set, MountPropagationNone is used. This field is beta
-                        in 1.10.
                       type: string
                     name:
-                      description: This must match the Name of a Volume.
                       type: string
                     readOnly:
-                      description: Mounted read-only if true, read-write otherwise
-                        (false or unspecified). Defaults to false.
                       type: boolean
                     subPath:
-                      description: Path within the volume from which the container's
-                        volume should be mounted. Defaults to "" (volume's root).
                       type: string
                     subPathExpr:
-                      description: Expanded path within the volume from which the
-                        container's volume should be mounted. Behaves similarly to
-                        SubPath but environment variable references $(VAR_NAME) are
-                        expanded using the container's environment. Defaults to ""
-                        (volume's root). SubPathExpr and SubPath are mutually exclusive.
                       type: string
                   required:
                   - mountPath
@@ -6233,224 +2999,106 @@ spec:
                   type: object
                 type: array
               volumes:
-                description: Volumes allows configuration of additional volumes on
-                  the output StatefulSet definition. The volumes specified are appended
-                  to other volumes that are generated as a result of StorageSpec objects.
                 items:
-                  description: Volume represents a named volume in a pod that may
-                    be accessed by any container in the pod.
                   properties:
                     awsElasticBlockStore:
-                      description: 'awsElasticBlockStore represents an AWS Disk resource
-                        that is attached to a kubelet''s host machine and then exposed
-                        to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                       properties:
                         fsType:
-                          description: 'fsType is the filesystem type of the volume
-                            that you want to mount. Tip: Ensure that the filesystem
-                            type is supported by the host operating system. Examples:
-                            "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
-                            if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                            TODO: how do we prevent errors in the filesystem from
-                            compromising the machine'
                           type: string
                         partition:
-                          description: 'partition is the partition in the volume that
-                            you want to mount. If omitted, the default is to mount
-                            by volume name. Examples: For volume /dev/sda1, you specify
-                            the partition as "1". Similarly, the volume partition
-                            for /dev/sda is "0" (or you can leave the property empty).'
                           format: int32
                           type: integer
                         readOnly:
-                          description: 'readOnly value true will force the readOnly
-                            setting in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                           type: boolean
                         volumeID:
-                          description: 'volumeID is unique ID of the persistent disk
-                            resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                           type: string
                       required:
                       - volumeID
                       type: object
                     azureDisk:
-                      description: azureDisk represents an Azure Data Disk mount on
-                        the host and bind mount to the pod.
                       properties:
                         cachingMode:
-                          description: 'cachingMode is the Host Caching mode: None,
-                            Read Only, Read Write.'
                           type: string
                         diskName:
-                          description: diskName is the Name of the data disk in the
-                            blob storage
                           type: string
                         diskURI:
-                          description: diskURI is the URI of data disk in the blob
-                            storage
                           type: string
                         fsType:
-                          description: fsType is Filesystem type to mount. Must be
-                            a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
-                            if unspecified.
                           type: string
                         kind:
-                          description: 'kind expected values are Shared: multiple
-                            blob disks per storage account  Dedicated: single blob
-                            disk per storage account  Managed: azure managed data
-                            disk (only in managed availability set). defaults to shared'
                           type: string
                         readOnly:
-                          description: readOnly Defaults to false (read/write). ReadOnly
-                            here will force the ReadOnly setting in VolumeMounts.
                           type: boolean
                       required:
                       - diskName
                       - diskURI
                       type: object
                     azureFile:
-                      description: azureFile represents an Azure File Service mount
-                        on the host and bind mount to the pod.
                       properties:
                         readOnly:
-                          description: readOnly defaults to false (read/write). ReadOnly
-                            here will force the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretName:
-                          description: secretName is the  name of secret that contains
-                            Azure Storage Account Name and Key
                           type: string
                         shareName:
-                          description: shareName is the azure share Name
                           type: string
                       required:
                       - secretName
                       - shareName
                       type: object
                     cephfs:
-                      description: cephFS represents a Ceph FS mount on the host that
-                        shares a pod's lifetime
                       properties:
                         monitors:
-                          description: 'monitors is Required: Monitors is a collection
-                            of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                           items:
                             type: string
                           type: array
                         path:
-                          description: 'path is Optional: Used as the mounted root,
-                            rather than the full Ceph tree, default is /'
                           type: string
                         readOnly:
-                          description: 'readOnly is Optional: Defaults to false (read/write).
-                            ReadOnly here will force the ReadOnly setting in VolumeMounts.
-                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                           type: boolean
                         secretFile:
-                          description: 'secretFile is Optional: SecretFile is the
-                            path to key ring for User, default is /etc/ceph/user.secret
-                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                           type: string
                         secretRef:
-                          description: 'secretRef is Optional: SecretRef is reference
-                            to the authentication secret for User, default is empty.
-                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                           properties:
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         user:
-                          description: 'user is optional: User is the rados user name,
-                            default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                           type: string
                       required:
                       - monitors
                       type: object
                     cinder:
-                      description: 'cinder represents a cinder volume attached and
-                        mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                       properties:
                         fsType:
-                          description: 'fsType is the filesystem type to mount. Must
-                            be a filesystem type supported by the host operating system.
-                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to
-                            be "ext4" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                           type: string
                         readOnly:
-                          description: 'readOnly defaults to false (read/write). ReadOnly
-                            here will force the ReadOnly setting in VolumeMounts.
-                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                           type: boolean
                         secretRef:
-                          description: 'secretRef is optional: points to a secret
-                            object containing parameters used to connect to OpenStack.'
                           properties:
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         volumeID:
-                          description: 'volumeID used to identify the volume in cinder.
-                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                           type: string
                       required:
                       - volumeID
                       type: object
                     configMap:
-                      description: configMap represents a configMap that should populate
-                        this volume
                       properties:
                         defaultMode:
-                          description: 'defaultMode is optional: mode bits used to
-                            set permissions on created files by default. Must be an
-                            octal value between 0000 and 0777 or a decimal value between
-                            0 and 511. YAML accepts both octal and decimal values,
-                            JSON requires decimal values for mode bits. Defaults to
-                            0644. Directories within the path are not affected by
-                            this setting. This might be in conflict with other options
-                            that affect the file mode, like fsGroup, and the result
-                            can be other mode bits set.'
                           format: int32
                           type: integer
                         items:
-                          description: items if unspecified, each key-value pair in
-                            the Data field of the referenced ConfigMap will be projected
-                            into the volume as a file whose name is the key and content
-                            is the value. If specified, the listed keys will be projected
-                            into the specified paths, and unlisted keys will not be
-                            present. If a key is specified which is not present in
-                            the ConfigMap, the volume setup will error unless it is
-                            marked optional. Paths must be relative and may not contain
-                            the '..' path or start with '..'.
                           items:
-                            description: Maps a string key to a path within a volume.
                             properties:
                               key:
-                                description: key is the key to project.
                                 type: string
                               mode:
-                                description: 'mode is Optional: mode bits used to
-                                  set permissions on this file. Must be an octal value
-                                  between 0000 and 0777 or a decimal value between
-                                  0 and 511. YAML accepts both octal and decimal values,
-                                  JSON requires decimal values for mode bits. If not
-                                  specified, the volume defaultMode will be used.
-                                  This might be in conflict with other options that
-                                  affect the file mode, like fsGroup, and the result
-                                  can be other mode bits set.'
                                 format: int32
                                 type: integer
                               path:
-                                description: path is the relative path of the file
-                                  to map the key to. May not be an absolute path.
-                                  May not contain the path element '..'. May not start
-                                  with the string '..'.
                                 type: string
                             required:
                             - key
@@ -6458,139 +3106,66 @@ spec:
                             type: object
                           type: array
                         name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?'
                           type: string
                         optional:
-                          description: optional specify whether the ConfigMap or its
-                            keys must be defined
                           type: boolean
                       type: object
                       x-kubernetes-map-type: atomic
                     csi:
-                      description: csi (Container Storage Interface) represents ephemeral
-                        storage that is handled by certain external CSI drivers (Beta
-                        feature).
                       properties:
                         driver:
-                          description: driver is the name of the CSI driver that handles
-                            this volume. Consult with your admin for the correct name
-                            as registered in the cluster.
                           type: string
                         fsType:
-                          description: fsType to mount. Ex. "ext4", "xfs", "ntfs".
-                            If not provided, the empty value is passed to the associated
-                            CSI driver which will determine the default filesystem
-                            to apply.
                           type: string
                         nodePublishSecretRef:
-                          description: nodePublishSecretRef is a reference to the
-                            secret object containing sensitive information to pass
-                            to the CSI driver to complete the CSI NodePublishVolume
-                            and NodeUnpublishVolume calls. This field is optional,
-                            and  may be empty if no secret is required. If the secret
-                            object contains more than one secret, all secret references
-                            are passed.
                           properties:
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         readOnly:
-                          description: readOnly specifies a read-only configuration
-                            for the volume. Defaults to false (read/write).
                           type: boolean
                         volumeAttributes:
                           additionalProperties:
                             type: string
-                          description: volumeAttributes stores driver-specific properties
-                            that are passed to the CSI driver. Consult your driver's
-                            documentation for supported values.
                           type: object
                       required:
                       - driver
                       type: object
                     downwardAPI:
-                      description: downwardAPI represents downward API about the pod
-                        that should populate this volume
                       properties:
                         defaultMode:
-                          description: 'Optional: mode bits to use on created files
-                            by default. Must be a Optional: mode bits used to set
-                            permissions on created files by default. Must be an octal
-                            value between 0000 and 0777 or a decimal value between
-                            0 and 511. YAML accepts both octal and decimal values,
-                            JSON requires decimal values for mode bits. Defaults to
-                            0644. Directories within the path are not affected by
-                            this setting. This might be in conflict with other options
-                            that affect the file mode, like fsGroup, and the result
-                            can be other mode bits set.'
                           format: int32
                           type: integer
                         items:
-                          description: Items is a list of downward API volume file
                           items:
-                            description: DownwardAPIVolumeFile represents information
-                              to create the file containing the pod field
                             properties:
                               fieldRef:
-                                description: 'Required: Selects a field of the pod:
-                                  only annotations, labels, name and namespace are
-                                  supported.'
                                 properties:
                                   apiVersion:
-                                    description: Version of the schema the FieldPath
-                                      is written in terms of, defaults to "v1".
                                     type: string
                                   fieldPath:
-                                    description: Path of the field to select in the
-                                      specified API version.
                                     type: string
                                 required:
                                 - fieldPath
                                 type: object
                                 x-kubernetes-map-type: atomic
                               mode:
-                                description: 'Optional: mode bits used to set permissions
-                                  on this file, must be an octal value between 0000
-                                  and 0777 or a decimal value between 0 and 511. YAML
-                                  accepts both octal and decimal values, JSON requires
-                                  decimal values for mode bits. If not specified,
-                                  the volume defaultMode will be used. This might
-                                  be in conflict with other options that affect the
-                                  file mode, like fsGroup, and the result can be other
-                                  mode bits set.'
                                 format: int32
                                 type: integer
                               path:
-                                description: 'Required: Path is  the relative path
-                                  name of the file to be created. Must not be absolute
-                                  or contain the ''..'' path. Must be utf-8 encoded.
-                                  The first item of the relative path must not start
-                                  with ''..'''
                                 type: string
                               resourceFieldRef:
-                                description: 'Selects a resource of the container:
-                                  only resources limits and requests (limits.cpu,
-                                  limits.memory, requests.cpu and requests.memory)
-                                  are currently supported.'
                                 properties:
                                   containerName:
-                                    description: 'Container name: required for volumes,
-                                      optional for env vars'
                                     type: string
                                   divisor:
                                     anyOf:
                                     - type: integer
                                     - type: string
-                                    description: Specifies the output format of the
-                                      exposed resources, defaults to "1"
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                   resource:
-                                    description: 'Required: resource to select'
                                     type: string
                                 required:
                                 - resource
@@ -6602,114 +3177,35 @@ spec:
                           type: array
                       type: object
                     emptyDir:
-                      description: 'emptyDir represents a temporary directory that
-                        shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                       properties:
                         medium:
-                          description: 'medium represents what type of storage medium
-                            should back this directory. The default is "" which means
-                            to use the node''s default medium. Must be an empty string
-                            (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                           type: string
                         sizeLimit:
                           anyOf:
                           - type: integer
                           - type: string
-                          description: 'sizeLimit is the total amount of local storage
-                            required for this EmptyDir volume. The size limit is also
-                            applicable for memory medium. The maximum usage on memory
-                            medium EmptyDir would be the minimum value between the
-                            SizeLimit specified here and the sum of memory limits
-                            of all containers in a pod. The default is nil which means
-                            that the limit is undefined. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                       type: object
                     ephemeral:
-                      description: "ephemeral represents a volume that is handled
-                        by a cluster storage driver. The volume's lifecycle is tied
-                        to the pod that defines it - it will be created before the
-                        pod starts, and deleted when the pod is removed. \n Use this
-                        if: a) the volume is only needed while the pod runs, b) features
-                        of normal volumes like restoring from snapshot or capacity
-                        tracking are needed, c) the storage driver is specified through
-                        a storage class, and d) the storage driver supports dynamic
-                        volume provisioning through a PersistentVolumeClaim (see EphemeralVolumeSource
-                        for more information on the connection between this volume
-                        type and PersistentVolumeClaim). \n Use PersistentVolumeClaim
-                        or one of the vendor-specific APIs for volumes that persist
-                        for longer than the lifecycle of an individual pod. \n Use
-                        CSI for light-weight local ephemeral volumes if the CSI driver
-                        is meant to be used that way - see the documentation of the
-                        driver for more information. \n A pod can use both types of
-                        ephemeral volumes and persistent volumes at the same time."
                       properties:
                         volumeClaimTemplate:
-                          description: "Will be used to create a stand-alone PVC to
-                            provision the volume. The pod in which this EphemeralVolumeSource
-                            is embedded will be the owner of the PVC, i.e. the PVC
-                            will be deleted together with the pod.  The name of the
-                            PVC will be `<pod name>-<volume name>` where `<volume
-                            name>` is the name from the `PodSpec.Volumes` array entry.
-                            Pod validation will reject the pod if the concatenated
-                            name is not valid for a PVC (for example, too long). \n
-                            An existing PVC with that name that is not owned by the
-                            pod will *not* be used for the pod to avoid using an unrelated
-                            volume by mistake. Starting the pod is then blocked until
-                            the unrelated PVC is removed. If such a pre-created PVC
-                            is meant to be used by the pod, the PVC has to updated
-                            with an owner reference to the pod once the pod exists.
-                            Normally this should not be necessary, but it may be useful
-                            when manually reconstructing a broken cluster. \n This
-                            field is read-only and no changes will be made by Kubernetes
-                            to the PVC after it has been created. \n Required, must
-                            not be nil."
                           properties:
                             metadata:
-                              description: May contain labels and annotations that
-                                will be copied into the PVC when creating it. No other
-                                fields are allowed and will be rejected during validation.
                               type: object
                             spec:
-                              description: The specification for the PersistentVolumeClaim.
-                                The entire content is copied unchanged into the PVC
-                                that gets created from this template. The same fields
-                                as in a PersistentVolumeClaim are also valid here.
                               properties:
                                 accessModes:
-                                  description: 'accessModes contains the desired access
-                                    modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                                   items:
                                     type: string
                                   type: array
                                 dataSource:
-                                  description: 'dataSource field can be used to specify
-                                    either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                                    * An existing PVC (PersistentVolumeClaim) If the
-                                    provisioner or an external controller can support
-                                    the specified data source, it will create a new
-                                    volume based on the contents of the specified
-                                    data source. When the AnyVolumeDataSource feature
-                                    gate is enabled, dataSource contents will be copied
-                                    to dataSourceRef, and dataSourceRef contents will
-                                    be copied to dataSource when dataSourceRef.namespace
-                                    is not specified. If the namespace is specified,
-                                    then dataSourceRef will not be copied to dataSource.'
                                   properties:
                                     apiGroup:
-                                      description: APIGroup is the group for the resource
-                                        being referenced. If APIGroup is not specified,
-                                        the specified Kind must be in the core API
-                                        group. For any other third-party types, APIGroup
-                                        is required.
                                       type: string
                                     kind:
-                                      description: Kind is the type of resource being
-                                        referenced
                                       type: string
                                     name:
-                                      description: Name is the name of resource being
-                                        referenced
                                       type: string
                                   required:
                                   - kind
@@ -6717,94 +3213,25 @@ spec:
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 dataSourceRef:
-                                  description: 'dataSourceRef specifies the object
-                                    from which to populate the volume with data, if
-                                    a non-empty volume is desired. This may be any
-                                    object from a non-empty API group (non core object)
-                                    or a PersistentVolumeClaim object. When this field
-                                    is specified, volume binding will only succeed
-                                    if the type of the specified object matches some
-                                    installed volume populator or dynamic provisioner.
-                                    This field will replace the functionality of the
-                                    dataSource field and as such if both fields are
-                                    non-empty, they must have the same value. For
-                                    backwards compatibility, when namespace isn''t
-                                    specified in dataSourceRef, both fields (dataSource
-                                    and dataSourceRef) will be set to the same value
-                                    automatically if one of them is empty and the
-                                    other is non-empty. When namespace is specified
-                                    in dataSourceRef, dataSource isn''t set to the
-                                    same value and must be empty. There are three
-                                    important differences between dataSource and dataSourceRef:
-                                    * While dataSource only allows two specific types
-                                    of objects, dataSourceRef allows any non-core
-                                    object, as well as PersistentVolumeClaim objects.
-                                    * While dataSource ignores disallowed values (dropping
-                                    them), dataSourceRef preserves all values, and
-                                    generates an error if a disallowed value is specified.
-                                    * While dataSource only allows local objects,
-                                    dataSourceRef allows objects in any namespaces.
-                                    (Beta) Using this field requires the AnyVolumeDataSource
-                                    feature gate to be enabled. (Alpha) Using the
-                                    namespace field of dataSourceRef requires the
-                                    CrossNamespaceVolumeDataSource feature gate to
-                                    be enabled.'
                                   properties:
                                     apiGroup:
-                                      description: APIGroup is the group for the resource
-                                        being referenced. If APIGroup is not specified,
-                                        the specified Kind must be in the core API
-                                        group. For any other third-party types, APIGroup
-                                        is required.
                                       type: string
                                     kind:
-                                      description: Kind is the type of resource being
-                                        referenced
                                       type: string
                                     name:
-                                      description: Name is the name of resource being
-                                        referenced
                                       type: string
                                     namespace:
-                                      description: Namespace is the namespace of resource
-                                        being referenced Note that when a namespace
-                                        is specified, a gateway.networking.k8s.io/ReferenceGrant
-                                        object is required in the referent namespace
-                                        to allow that namespace's owner to accept
-                                        the reference. See the ReferenceGrant documentation
-                                        for details. (Alpha) This field requires the
-                                        CrossNamespaceVolumeDataSource feature gate
-                                        to be enabled.
                                       type: string
                                   required:
                                   - kind
                                   - name
                                   type: object
                                 resources:
-                                  description: 'resources represents the minimum resources
-                                    the volume should have. If RecoverVolumeExpansionFailure
-                                    feature is enabled users are allowed to specify
-                                    resource requirements that are lower than previous
-                                    value but must still be higher than capacity recorded
-                                    in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                                   properties:
                                     claims:
-                                      description: "Claims lists the names of resources,
-                                        defined in spec.resourceClaims, that are used
-                                        by this container. \n This is an alpha field
-                                        and requires enabling the DynamicResourceAllocation
-                                        feature gate. \n This field is immutable.
-                                        It can only be set for containers."
                                       items:
-                                        description: ResourceClaim references one
-                                          entry in PodSpec.ResourceClaims.
                                         properties:
                                           name:
-                                            description: Name must match the name
-                                              of one entry in pod.spec.resourceClaims
-                                              of the Pod where this field is used.
-                                              It makes that resource available inside
-                                              a container.
                                             type: string
                                         required:
                                         - name
@@ -6820,8 +3247,6 @@ spec:
                                         - type: string
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
-                                      description: 'Limits describes the maximum amount
-                                        of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                       type: object
                                     requests:
                                       additionalProperties:
@@ -6830,46 +3255,18 @@ spec:
                                         - type: string
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
-                                      description: 'Requests describes the minimum
-                                        amount of compute resources required. If Requests
-                                        is omitted for a container, it defaults to
-                                        Limits if that is explicitly specified, otherwise
-                                        to an implementation-defined value. Requests
-                                        cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                       type: object
                                   type: object
                                 selector:
-                                  description: selector is a label query over volumes
-                                    to consider for binding.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
                                       items:
-                                        description: A label selector requirement
-                                          is a selector that contains values, a key,
-                                          and an operator that relates the key and
-                                          values.
                                         properties:
                                           key:
-                                            description: key is the label key that
-                                              the selector applies to.
                                             type: string
                                           operator:
-                                            description: operator represents a key's
-                                              relationship to a set of values. Valid
-                                              operators are In, NotIn, Exists and
-                                              DoesNotExist.
                                             type: string
                                           values:
-                                            description: values is an array of string
-                                              values. If the operator is In or NotIn,
-                                              the values array must be non-empty.
-                                              If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This
-                                              array is replaced during a strategic
-                                              merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -6881,28 +3278,14 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: matchLabels is a map of {key,value}
-                                        pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions,
-                                        whose key field is "key", the operator is
-                                        "In", and the values array contains only "value".
-                                        The requirements are ANDed.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 storageClassName:
-                                  description: 'storageClassName is the name of the
-                                    StorageClass required by the claim. More info:
-                                    https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                                   type: string
                                 volumeMode:
-                                  description: volumeMode defines what type of volume
-                                    is required by the claim. Value of Filesystem
-                                    is implied when not included in claim spec.
                                   type: string
                                 volumeName:
-                                  description: volumeName is the binding reference
-                                    to the PersistentVolume backing this claim.
                                   type: string
                               type: object
                           required:
@@ -6910,74 +3293,38 @@ spec:
                           type: object
                       type: object
                     fc:
-                      description: fc represents a Fibre Channel resource that is
-                        attached to a kubelet's host machine and then exposed to the
-                        pod.
                       properties:
                         fsType:
-                          description: 'fsType is the filesystem type to mount. Must
-                            be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
-                            if unspecified. TODO: how do we prevent errors in the
-                            filesystem from compromising the machine'
                           type: string
                         lun:
-                          description: 'lun is Optional: FC target lun number'
                           format: int32
                           type: integer
                         readOnly:
-                          description: 'readOnly is Optional: Defaults to false (read/write).
-                            ReadOnly here will force the ReadOnly setting in VolumeMounts.'
                           type: boolean
                         targetWWNs:
-                          description: 'targetWWNs is Optional: FC target worldwide
-                            names (WWNs)'
                           items:
                             type: string
                           type: array
                         wwids:
-                          description: 'wwids Optional: FC volume world wide identifiers
-                            (wwids) Either wwids or combination of targetWWNs and
-                            lun must be set, but not both simultaneously.'
                           items:
                             type: string
                           type: array
                       type: object
                     flexVolume:
-                      description: flexVolume represents a generic volume resource
-                        that is provisioned/attached using an exec based plugin.
                       properties:
                         driver:
-                          description: driver is the name of the driver to use for
-                            this volume.
                           type: string
                         fsType:
-                          description: fsType is the filesystem type to mount. Must
-                            be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". The default filesystem depends
-                            on FlexVolume script.
                           type: string
                         options:
                           additionalProperties:
                             type: string
-                          description: 'options is Optional: this field holds extra
-                            command options if any.'
                           type: object
                         readOnly:
-                          description: 'readOnly is Optional: defaults to false (read/write).
-                            ReadOnly here will force the ReadOnly setting in VolumeMounts.'
                           type: boolean
                         secretRef:
-                          description: 'secretRef is Optional: secretRef is reference
-                            to the secret object containing sensitive information
-                            to pass to the plugin scripts. This may be empty if no
-                            secret object is specified. If the secret object contains
-                            more than one secret, all secrets are passed to the plugin
-                            scripts.'
                           properties:
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
@@ -6985,184 +3332,88 @@ spec:
                       - driver
                       type: object
                     flocker:
-                      description: flocker represents a Flocker volume attached to
-                        a kubelet's host machine. This depends on the Flocker control
-                        service being running
                       properties:
                         datasetName:
-                          description: datasetName is Name of the dataset stored as
-                            metadata -> name on the dataset for Flocker should be
-                            considered as deprecated
                           type: string
                         datasetUUID:
-                          description: datasetUUID is the UUID of the dataset. This
-                            is unique identifier of a Flocker dataset
                           type: string
                       type: object
                     gcePersistentDisk:
-                      description: 'gcePersistentDisk represents a GCE Disk resource
-                        that is attached to a kubelet''s host machine and then exposed
-                        to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                       properties:
                         fsType:
-                          description: 'fsType is filesystem type of the volume that
-                            you want to mount. Tip: Ensure that the filesystem type
-                            is supported by the host operating system. Examples: "ext4",
-                            "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                            TODO: how do we prevent errors in the filesystem from
-                            compromising the machine'
                           type: string
                         partition:
-                          description: 'partition is the partition in the volume that
-                            you want to mount. If omitted, the default is to mount
-                            by volume name. Examples: For volume /dev/sda1, you specify
-                            the partition as "1". Similarly, the volume partition
-                            for /dev/sda is "0" (or you can leave the property empty).
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                           format: int32
                           type: integer
                         pdName:
-                          description: 'pdName is unique name of the PD resource in
-                            GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                           type: string
                         readOnly:
-                          description: 'readOnly here will force the ReadOnly setting
-                            in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                           type: boolean
                       required:
                       - pdName
                       type: object
                     gitRepo:
-                      description: 'gitRepo represents a git repository at a particular
-                        revision. DEPRECATED: GitRepo is deprecated. To provision
-                        a container with a git repo, mount an EmptyDir into an InitContainer
-                        that clones the repo using git, then mount the EmptyDir into
-                        the Pod''s container.'
                       properties:
                         directory:
-                          description: directory is the target directory name. Must
-                            not contain or start with '..'.  If '.' is supplied, the
-                            volume directory will be the git repository.  Otherwise,
-                            if specified, the volume will contain the git repository
-                            in the subdirectory with the given name.
                           type: string
                         repository:
-                          description: repository is the URL
                           type: string
                         revision:
-                          description: revision is the commit hash for the specified
-                            revision.
                           type: string
                       required:
                       - repository
                       type: object
                     glusterfs:
-                      description: 'glusterfs represents a Glusterfs mount on the
-                        host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
                       properties:
                         endpoints:
-                          description: 'endpoints is the endpoint name that details
-                            Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                           type: string
                         path:
-                          description: 'path is the Glusterfs volume path. More info:
-                            https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                           type: string
                         readOnly:
-                          description: 'readOnly here will force the Glusterfs volume
-                            to be mounted with read-only permissions. Defaults to
-                            false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                           type: boolean
                       required:
                       - endpoints
                       - path
                       type: object
                     hostPath:
-                      description: 'hostPath represents a pre-existing file or directory
-                        on the host machine that is directly exposed to the container.
-                        This is generally used for system agents or other privileged
-                        things that are allowed to see the host machine. Most containers
-                        will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                        --- TODO(jonesdl) We need to restrict who can use host directory
-                        mounts and who can/can not mount host directories as read/write.'
                       properties:
                         path:
-                          description: 'path of the directory on the host. If the
-                            path is a symlink, it will follow the link to the real
-                            path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                           type: string
                         type:
-                          description: 'type for HostPath Volume Defaults to "" More
-                            info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                           type: string
                       required:
                       - path
                       type: object
                     iscsi:
-                      description: 'iscsi represents an ISCSI Disk resource that is
-                        attached to a kubelet''s host machine and then exposed to
-                        the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
                       properties:
                         chapAuthDiscovery:
-                          description: chapAuthDiscovery defines whether support iSCSI
-                            Discovery CHAP authentication
                           type: boolean
                         chapAuthSession:
-                          description: chapAuthSession defines whether support iSCSI
-                            Session CHAP authentication
                           type: boolean
                         fsType:
-                          description: 'fsType is the filesystem type of the volume
-                            that you want to mount. Tip: Ensure that the filesystem
-                            type is supported by the host operating system. Examples:
-                            "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
-                            if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                            TODO: how do we prevent errors in the filesystem from
-                            compromising the machine'
                           type: string
                         initiatorName:
-                          description: initiatorName is the custom iSCSI Initiator
-                            Name. If initiatorName is specified with iscsiInterface
-                            simultaneously, new iSCSI interface <target portal>:<volume
-                            name> will be created for the connection.
                           type: string
                         iqn:
-                          description: iqn is the target iSCSI Qualified Name.
                           type: string
                         iscsiInterface:
-                          description: iscsiInterface is the interface Name that uses
-                            an iSCSI transport. Defaults to 'default' (tcp).
                           type: string
                         lun:
-                          description: lun represents iSCSI Target Lun number.
                           format: int32
                           type: integer
                         portals:
-                          description: portals is the iSCSI Target Portal List. The
-                            portal is either an IP or ip_addr:port if the port is
-                            other than default (typically TCP ports 860 and 3260).
                           items:
                             type: string
                           type: array
                         readOnly:
-                          description: readOnly here will force the ReadOnly setting
-                            in VolumeMounts. Defaults to false.
                           type: boolean
                         secretRef:
-                          description: secretRef is the CHAP Secret for iSCSI target
-                            and initiator authentication
                           properties:
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         targetPortal:
-                          description: targetPortal is iSCSI Target Portal. The Portal
-                            is either an IP or ip_addr:port if the port is other than
-                            default (typically TCP ports 860 and 3260).
                           type: string
                       required:
                       - iqn
@@ -7170,148 +3421,67 @@ spec:
                       - targetPortal
                       type: object
                     name:
-                      description: 'name of the volume. Must be a DNS_LABEL and unique
-                        within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                       type: string
                     nfs:
-                      description: 'nfs represents an NFS mount on the host that shares
-                        a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                       properties:
                         path:
-                          description: 'path that is exported by the NFS server. More
-                            info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                           type: string
                         readOnly:
-                          description: 'readOnly here will force the NFS export to
-                            be mounted with read-only permissions. Defaults to false.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                           type: boolean
                         server:
-                          description: 'server is the hostname or IP address of the
-                            NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                           type: string
                       required:
                       - path
                       - server
                       type: object
                     persistentVolumeClaim:
-                      description: 'persistentVolumeClaimVolumeSource represents a
-                        reference to a PersistentVolumeClaim in the same namespace.
-                        More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                       properties:
                         claimName:
-                          description: 'claimName is the name of a PersistentVolumeClaim
-                            in the same namespace as the pod using this volume. More
-                            info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                           type: string
                         readOnly:
-                          description: readOnly Will force the ReadOnly setting in
-                            VolumeMounts. Default false.
                           type: boolean
                       required:
                       - claimName
                       type: object
                     photonPersistentDisk:
-                      description: photonPersistentDisk represents a PhotonController
-                        persistent disk attached and mounted on kubelets host machine
                       properties:
                         fsType:
-                          description: fsType is the filesystem type to mount. Must
-                            be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
-                            if unspecified.
                           type: string
                         pdID:
-                          description: pdID is the ID that identifies Photon Controller
-                            persistent disk
                           type: string
                       required:
                       - pdID
                       type: object
                     portworxVolume:
-                      description: portworxVolume represents a portworx volume attached
-                        and mounted on kubelets host machine
                       properties:
                         fsType:
-                          description: fSType represents the filesystem type to mount
-                            Must be a filesystem type supported by the host operating
-                            system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4"
-                            if unspecified.
                           type: string
                         readOnly:
-                          description: readOnly defaults to false (read/write). ReadOnly
-                            here will force the ReadOnly setting in VolumeMounts.
                           type: boolean
                         volumeID:
-                          description: volumeID uniquely identifies a Portworx volume
                           type: string
                       required:
                       - volumeID
                       type: object
                     projected:
-                      description: projected items for all in one resources secrets,
-                        configmaps, and downward API
                       properties:
                         defaultMode:
-                          description: defaultMode are the mode bits used to set permissions
-                            on created files by default. Must be an octal value between
-                            0000 and 0777 or a decimal value between 0 and 511. YAML
-                            accepts both octal and decimal values, JSON requires decimal
-                            values for mode bits. Directories within the path are
-                            not affected by this setting. This might be in conflict
-                            with other options that affect the file mode, like fsGroup,
-                            and the result can be other mode bits set.
                           format: int32
                           type: integer
                         sources:
-                          description: sources is the list of volume projections
                           items:
-                            description: Projection that may be projected along with
-                              other supported volume types
                             properties:
                               configMap:
-                                description: configMap information about the configMap
-                                  data to project
                                 properties:
                                   items:
-                                    description: items if unspecified, each key-value
-                                      pair in the Data field of the referenced ConfigMap
-                                      will be projected into the volume as a file
-                                      whose name is the key and content is the value.
-                                      If specified, the listed keys will be projected
-                                      into the specified paths, and unlisted keys
-                                      will not be present. If a key is specified which
-                                      is not present in the ConfigMap, the volume
-                                      setup will error unless it is marked optional.
-                                      Paths must be relative and may not contain the
-                                      '..' path or start with '..'.
                                     items:
-                                      description: Maps a string key to a path within
-                                        a volume.
                                       properties:
                                         key:
-                                          description: key is the key to project.
                                           type: string
                                         mode:
-                                          description: 'mode is Optional: mode bits
-                                            used to set permissions on this file.
-                                            Must be an octal value between 0000 and
-                                            0777 or a decimal value between 0 and
-                                            511. YAML accepts both octal and decimal
-                                            values, JSON requires decimal values for
-                                            mode bits. If not specified, the volume
-                                            defaultMode will be used. This might be
-                                            in conflict with other options that affect
-                                            the file mode, like fsGroup, and the result
-                                            can be other mode bits set.'
                                           format: int32
                                           type: integer
                                         path:
-                                          description: path is the relative path of
-                                            the file to map the key to. May not be
-                                            an absolute path. May not contain the
-                                            path element '..'. May not start with
-                                            the string '..'.
                                           type: string
                                       required:
                                       - key
@@ -7319,91 +3489,42 @@ spec:
                                       type: object
                                     type: array
                                   name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
                                     type: string
                                   optional:
-                                    description: optional specify whether the ConfigMap
-                                      or its keys must be defined
                                     type: boolean
                                 type: object
                                 x-kubernetes-map-type: atomic
                               downwardAPI:
-                                description: downwardAPI information about the downwardAPI
-                                  data to project
                                 properties:
                                   items:
-                                    description: Items is a list of DownwardAPIVolume
-                                      file
                                     items:
-                                      description: DownwardAPIVolumeFile represents
-                                        information to create the file containing
-                                        the pod field
                                       properties:
                                         fieldRef:
-                                          description: 'Required: Selects a field
-                                            of the pod: only annotations, labels,
-                                            name and namespace are supported.'
                                           properties:
                                             apiVersion:
-                                              description: Version of the schema the
-                                                FieldPath is written in terms of,
-                                                defaults to "v1".
                                               type: string
                                             fieldPath:
-                                              description: Path of the field to select
-                                                in the specified API version.
                                               type: string
                                           required:
                                           - fieldPath
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         mode:
-                                          description: 'Optional: mode bits used to
-                                            set permissions on this file, must be
-                                            an octal value between 0000 and 0777 or
-                                            a decimal value between 0 and 511. YAML
-                                            accepts both octal and decimal values,
-                                            JSON requires decimal values for mode
-                                            bits. If not specified, the volume defaultMode
-                                            will be used. This might be in conflict
-                                            with other options that affect the file
-                                            mode, like fsGroup, and the result can
-                                            be other mode bits set.'
                                           format: int32
                                           type: integer
                                         path:
-                                          description: 'Required: Path is  the relative
-                                            path name of the file to be created. Must
-                                            not be absolute or contain the ''..''
-                                            path. Must be utf-8 encoded. The first
-                                            item of the relative path must not start
-                                            with ''..'''
                                           type: string
                                         resourceFieldRef:
-                                          description: 'Selects a resource of the
-                                            container: only resources limits and requests
-                                            (limits.cpu, limits.memory, requests.cpu
-                                            and requests.memory) are currently supported.'
                                           properties:
                                             containerName:
-                                              description: 'Container name: required
-                                                for volumes, optional for env vars'
                                               type: string
                                             divisor:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Specifies the output format
-                                                of the exposed resources, defaults
-                                                to "1"
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
                                             resource:
-                                              description: 'Required: resource to
-                                                select'
                                               type: string
                                           required:
                                           - resource
@@ -7415,48 +3536,16 @@ spec:
                                     type: array
                                 type: object
                               secret:
-                                description: secret information about the secret data
-                                  to project
                                 properties:
                                   items:
-                                    description: items if unspecified, each key-value
-                                      pair in the Data field of the referenced Secret
-                                      will be projected into the volume as a file
-                                      whose name is the key and content is the value.
-                                      If specified, the listed keys will be projected
-                                      into the specified paths, and unlisted keys
-                                      will not be present. If a key is specified which
-                                      is not present in the Secret, the volume setup
-                                      will error unless it is marked optional. Paths
-                                      must be relative and may not contain the '..'
-                                      path or start with '..'.
                                     items:
-                                      description: Maps a string key to a path within
-                                        a volume.
                                       properties:
                                         key:
-                                          description: key is the key to project.
                                           type: string
                                         mode:
-                                          description: 'mode is Optional: mode bits
-                                            used to set permissions on this file.
-                                            Must be an octal value between 0000 and
-                                            0777 or a decimal value between 0 and
-                                            511. YAML accepts both octal and decimal
-                                            values, JSON requires decimal values for
-                                            mode bits. If not specified, the volume
-                                            defaultMode will be used. This might be
-                                            in conflict with other options that affect
-                                            the file mode, like fsGroup, and the result
-                                            can be other mode bits set.'
                                           format: int32
                                           type: integer
                                         path:
-                                          description: path is the relative path of
-                                            the file to map the key to. May not be
-                                            an absolute path. May not contain the
-                                            path element '..'. May not start with
-                                            the string '..'.
                                           type: string
                                       required:
                                       - key
@@ -7464,45 +3553,19 @@ spec:
                                       type: object
                                     type: array
                                   name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
                                     type: string
                                   optional:
-                                    description: optional field specify whether the
-                                      Secret or its key must be defined
                                     type: boolean
                                 type: object
                                 x-kubernetes-map-type: atomic
                               serviceAccountToken:
-                                description: serviceAccountToken is information about
-                                  the serviceAccountToken data to project
                                 properties:
                                   audience:
-                                    description: audience is the intended audience
-                                      of the token. A recipient of a token must identify
-                                      itself with an identifier specified in the audience
-                                      of the token, and otherwise should reject the
-                                      token. The audience defaults to the identifier
-                                      of the apiserver.
                                     type: string
                                   expirationSeconds:
-                                    description: expirationSeconds is the requested
-                                      duration of validity of the service account
-                                      token. As the token approaches expiration, the
-                                      kubelet volume plugin will proactively rotate
-                                      the service account token. The kubelet will
-                                      start trying to rotate the token if the token
-                                      is older than 80 percent of its time to live
-                                      or if the token is older than 24 hours.Defaults
-                                      to 1 hour and must be at least 10 minutes.
                                     format: int64
                                     type: integer
                                   path:
-                                    description: path is the path relative to the
-                                      mount point of the file to project the token
-                                      into.
                                     type: string
                                 required:
                                 - path
@@ -7511,148 +3574,76 @@ spec:
                           type: array
                       type: object
                     quobyte:
-                      description: quobyte represents a Quobyte mount on the host
-                        that shares a pod's lifetime
                       properties:
                         group:
-                          description: group to map volume access to Default is no
-                            group
                           type: string
                         readOnly:
-                          description: readOnly here will force the Quobyte volume
-                            to be mounted with read-only permissions. Defaults to
-                            false.
                           type: boolean
                         registry:
-                          description: registry represents a single or multiple Quobyte
-                            Registry services specified as a string as host:port pair
-                            (multiple entries are separated with commas) which acts
-                            as the central registry for volumes
                           type: string
                         tenant:
-                          description: tenant owning the given Quobyte volume in the
-                            Backend Used with dynamically provisioned Quobyte volumes,
-                            value is set by the plugin
                           type: string
                         user:
-                          description: user to map volume access to Defaults to serivceaccount
-                            user
                           type: string
                         volume:
-                          description: volume is a string that references an already
-                            created Quobyte volume by name.
                           type: string
                       required:
                       - registry
                       - volume
                       type: object
                     rbd:
-                      description: 'rbd represents a Rados Block Device mount on the
-                        host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
                       properties:
                         fsType:
-                          description: 'fsType is the filesystem type of the volume
-                            that you want to mount. Tip: Ensure that the filesystem
-                            type is supported by the host operating system. Examples:
-                            "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
-                            if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                            TODO: how do we prevent errors in the filesystem from
-                            compromising the machine'
                           type: string
                         image:
-                          description: 'image is the rados image name. More info:
-                            https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                           type: string
                         keyring:
-                          description: 'keyring is the path to key ring for RBDUser.
-                            Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                           type: string
                         monitors:
-                          description: 'monitors is a collection of Ceph monitors.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                           items:
                             type: string
                           type: array
                         pool:
-                          description: 'pool is the rados pool name. Default is rbd.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                           type: string
                         readOnly:
-                          description: 'readOnly here will force the ReadOnly setting
-                            in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                           type: boolean
                         secretRef:
-                          description: 'secretRef is name of the authentication secret
-                            for RBDUser. If provided overrides keyring. Default is
-                            nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                           properties:
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         user:
-                          description: 'user is the rados user name. Default is admin.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                           type: string
                       required:
                       - image
                       - monitors
                       type: object
                     scaleIO:
-                      description: scaleIO represents a ScaleIO persistent volume
-                        attached and mounted on Kubernetes nodes.
                       properties:
                         fsType:
-                          description: fsType is the filesystem type to mount. Must
-                            be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". Default is "xfs".
                           type: string
                         gateway:
-                          description: gateway is the host address of the ScaleIO
-                            API Gateway.
                           type: string
                         protectionDomain:
-                          description: protectionDomain is the name of the ScaleIO
-                            Protection Domain for the configured storage.
                           type: string
                         readOnly:
-                          description: readOnly Defaults to false (read/write). ReadOnly
-                            here will force the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretRef:
-                          description: secretRef references to the secret for ScaleIO
-                            user and other sensitive information. If this is not provided,
-                            Login operation will fail.
                           properties:
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         sslEnabled:
-                          description: sslEnabled Flag enable/disable SSL communication
-                            with Gateway, default false
                           type: boolean
                         storageMode:
-                          description: storageMode indicates whether the storage for
-                            a volume should be ThickProvisioned or ThinProvisioned.
-                            Default is ThinProvisioned.
                           type: string
                         storagePool:
-                          description: storagePool is the ScaleIO Storage Pool associated
-                            with the protection domain.
                           type: string
                         system:
-                          description: system is the name of the storage system as
-                            configured in ScaleIO.
                           type: string
                         volumeName:
-                          description: volumeName is the name of a volume already
-                            created in the ScaleIO system that is associated with
-                            this volume source.
                           type: string
                       required:
                       - gateway
@@ -7660,54 +3651,19 @@ spec:
                       - system
                       type: object
                     secret:
-                      description: 'secret represents a secret that should populate
-                        this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                       properties:
                         defaultMode:
-                          description: 'defaultMode is Optional: mode bits used to
-                            set permissions on created files by default. Must be an
-                            octal value between 0000 and 0777 or a decimal value between
-                            0 and 511. YAML accepts both octal and decimal values,
-                            JSON requires decimal values for mode bits. Defaults to
-                            0644. Directories within the path are not affected by
-                            this setting. This might be in conflict with other options
-                            that affect the file mode, like fsGroup, and the result
-                            can be other mode bits set.'
                           format: int32
                           type: integer
                         items:
-                          description: items If unspecified, each key-value pair in
-                            the Data field of the referenced Secret will be projected
-                            into the volume as a file whose name is the key and content
-                            is the value. If specified, the listed keys will be projected
-                            into the specified paths, and unlisted keys will not be
-                            present. If a key is specified which is not present in
-                            the Secret, the volume setup will error unless it is marked
-                            optional. Paths must be relative and may not contain the
-                            '..' path or start with '..'.
                           items:
-                            description: Maps a string key to a path within a volume.
                             properties:
                               key:
-                                description: key is the key to project.
                                 type: string
                               mode:
-                                description: 'mode is Optional: mode bits used to
-                                  set permissions on this file. Must be an octal value
-                                  between 0000 and 0777 or a decimal value between
-                                  0 and 511. YAML accepts both octal and decimal values,
-                                  JSON requires decimal values for mode bits. If not
-                                  specified, the volume defaultMode will be used.
-                                  This might be in conflict with other options that
-                                  affect the file mode, like fsGroup, and the result
-                                  can be other mode bits set.'
                                 format: int32
                                 type: integer
                               path:
-                                description: path is the relative path of the file
-                                  to map the key to. May not be an absolute path.
-                                  May not contain the path element '..'. May not start
-                                  with the string '..'.
                                 type: string
                             required:
                             - key
@@ -7715,76 +3671,36 @@ spec:
                             type: object
                           type: array
                         optional:
-                          description: optional field specify whether the Secret or
-                            its keys must be defined
                           type: boolean
                         secretName:
-                          description: 'secretName is the name of the secret in the
-                            pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                           type: string
                       type: object
                     storageos:
-                      description: storageOS represents a StorageOS volume attached
-                        and mounted on Kubernetes nodes.
                       properties:
                         fsType:
-                          description: fsType is the filesystem type to mount. Must
-                            be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
-                            if unspecified.
                           type: string
                         readOnly:
-                          description: readOnly defaults to false (read/write). ReadOnly
-                            here will force the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretRef:
-                          description: secretRef specifies the secret to use for obtaining
-                            the StorageOS API credentials.  If not specified, default
-                            values will be attempted.
                           properties:
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         volumeName:
-                          description: volumeName is the human-readable name of the
-                            StorageOS volume.  Volume names are only unique within
-                            a namespace.
                           type: string
                         volumeNamespace:
-                          description: volumeNamespace specifies the scope of the
-                            volume within StorageOS.  If no namespace is specified
-                            then the Pod's namespace will be used.  This allows the
-                            Kubernetes name scoping to be mirrored within StorageOS
-                            for tighter integration. Set VolumeName to any name to
-                            override the default behaviour. Set to "default" if you
-                            are not using namespaces within StorageOS. Namespaces
-                            that do not pre-exist within StorageOS will be created.
                           type: string
                       type: object
                     vsphereVolume:
-                      description: vsphereVolume represents a vSphere volume attached
-                        and mounted on kubelets host machine
                       properties:
                         fsType:
-                          description: fsType is filesystem type to mount. Must be
-                            a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
-                            if unspecified.
                           type: string
                         storagePolicyID:
-                          description: storagePolicyID is the storage Policy Based
-                            Management (SPBM) profile ID associated with the StoragePolicyName.
                           type: string
                         storagePolicyName:
-                          description: storagePolicyName is the storage Policy Based
-                            Management (SPBM) profile name.
                           type: string
                         volumePath:
-                          description: volumePath is the path that identifies vSphere
-                            volume vmdk
                           type: string
                       required:
                       - volumePath
@@ -7819,55 +3735,26 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: "Integration runs a single Grafana Agent integration. Integrations
-          that generate telemetry must be configured to send that telemetry somewhere,
-          such as autoscrape for exporter-based integrations. \n Integrations have
-          access to the LogsInstances and MetricsInstances in the same GrafanaAgent
-          resource set, referenced by the <namespace>/<name> of the Instance resource.
-          \n For example, if there is a default/production MetricsInstance, you can
-          configure a supported integration's autoscrape block with: \n autoscrape:
-          enable: true metrics_instance: default/production \n There is currently
-          no way for telemetry created by an Operator-managed integration to be collected
-          from outside of the integration itself."
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           spec:
-            description: Specifies the desired behavior of the Integration.
             properties:
               config:
-                description: "The configuration for the named integration. Note that
-                  Integrations are deployed with the integrations-next feature flag,
-                  which has different common settings: \n https://grafana.com/docs/agent/latest/configuration/integrations/integrations-next/"
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
               configMaps:
-                description: "An extra list of keys from ConfigMaps in the same namespace
-                  as the Integration which will be mounted into the Grafana Agent
-                  pod running this Integration. \n ConfigMaps are mounted at /etc/grafana-agent/integrations/configMaps/<configmap_namespace>/<configmap_name>/<key>."
                 items:
-                  description: Selects a key from a ConfigMap.
                   properties:
                     key:
-                      description: The key to select.
                       type: string
                     name:
-                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                        TODO: Add other useful fields. apiVersion, kind, uid?'
                       type: string
                     optional:
-                      description: Specify whether the ConfigMap or its key must be
-                        defined
                       type: boolean
                   required:
                   - key
@@ -7875,26 +3762,15 @@ spec:
                   x-kubernetes-map-type: atomic
                 type: array
               name:
-                description: Name of the integration to run (e.g., "node_exporter",
-                  "mysqld_exporter").
                 type: string
               secrets:
-                description: "An extra list of keys from Secrets in the same namespace
-                  as the Integration which will be mounted into the Grafana Agent
-                  pod running this Integration. \n Secrets will be mounted at /etc/grafana-agent/integrations/secrets/<secret_namespace>/<secret_name>/<key>."
                 items:
-                  description: SecretKeySelector selects a key of a Secret.
                   properties:
                     key:
-                      description: The key of the secret to select from.  Must be
-                        a valid secret key.
                       type: string
                     name:
-                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                        TODO: Add other useful fields. apiVersion, kind, uid?'
                       type: string
                     optional:
-                      description: Specify whether the Secret or its key must be defined
                       type: boolean
                   required:
                   - key
@@ -7902,60 +3778,26 @@ spec:
                   x-kubernetes-map-type: atomic
                 type: array
               type:
-                description: Type informs Grafana Agent Operator about how to manage
-                  the integration being configured.
                 properties:
                   allNodes:
-                    description: When true, the configured integration should be run
-                      on every Node in the cluster. This is required for Integrations
-                      that generate Node-specific metrics like node_exporter, otherwise
-                      it must be false to avoid generating duplicate metrics.
                     type: boolean
                   unique:
-                    description: Whether this integration can only be defined once
-                      for a Grafana Agent process, such as statsd_exporter. It is
-                      invalid for a GrafanaAgent to discover multiple unique Integrations
-                      with the same Integration name (i.e., a single GrafanaAgent
-                      cannot deploy two statsd_exporters).
                     type: boolean
                 type: object
               volumeMounts:
-                description: "An extra list of VolumeMounts to be associated with
-                  the Grafana Agent pods running this integration. VolumeMount names
-                  are mutated to be unique across all used IntegrationSpecs. \n Mount
-                  paths should include the namespace/name of the Integration CR to
-                  avoid potentially colliding with other resources."
                 items:
-                  description: VolumeMount describes a mounting of a Volume within
-                    a container.
                   properties:
                     mountPath:
-                      description: Path within the container at which the volume should
-                        be mounted.  Must not contain ':'.
                       type: string
                     mountPropagation:
-                      description: mountPropagation determines how mounts are propagated
-                        from the host to container and the other way around. When
-                        not set, MountPropagationNone is used. This field is beta
-                        in 1.10.
                       type: string
                     name:
-                      description: This must match the Name of a Volume.
                       type: string
                     readOnly:
-                      description: Mounted read-only if true, read-write otherwise
-                        (false or unspecified). Defaults to false.
                       type: boolean
                     subPath:
-                      description: Path within the volume from which the container's
-                        volume should be mounted. Defaults to "" (volume's root).
                       type: string
                     subPathExpr:
-                      description: Expanded path within the volume from which the
-                        container's volume should be mounted. Behaves similarly to
-                        SubPath but environment variable references $(VAR_NAME) are
-                        expanded using the container's environment. Defaults to ""
-                        (volume's root). SubPathExpr and SubPath are mutually exclusive.
                       type: string
                   required:
                   - mountPath
@@ -7963,228 +3805,106 @@ spec:
                   type: object
                 type: array
               volumes:
-                description: "An extra list of Volumes to be associated with the Grafana
-                  Agent pods running this integration. Volume names are mutated to
-                  be unique across all Integrations. Note that the specified volumes
-                  should be able to tolerate existing on multiple pods at once when
-                  type is daemonset. \n Don't use volumes for loading Secrets or ConfigMaps
-                  from the same namespace as the Integration; use the Secrets and
-                  ConfigMaps fields instead."
                 items:
-                  description: Volume represents a named volume in a pod that may
-                    be accessed by any container in the pod.
                   properties:
                     awsElasticBlockStore:
-                      description: 'awsElasticBlockStore represents an AWS Disk resource
-                        that is attached to a kubelet''s host machine and then exposed
-                        to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                       properties:
                         fsType:
-                          description: 'fsType is the filesystem type of the volume
-                            that you want to mount. Tip: Ensure that the filesystem
-                            type is supported by the host operating system. Examples:
-                            "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
-                            if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                            TODO: how do we prevent errors in the filesystem from
-                            compromising the machine'
                           type: string
                         partition:
-                          description: 'partition is the partition in the volume that
-                            you want to mount. If omitted, the default is to mount
-                            by volume name. Examples: For volume /dev/sda1, you specify
-                            the partition as "1". Similarly, the volume partition
-                            for /dev/sda is "0" (or you can leave the property empty).'
                           format: int32
                           type: integer
                         readOnly:
-                          description: 'readOnly value true will force the readOnly
-                            setting in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                           type: boolean
                         volumeID:
-                          description: 'volumeID is unique ID of the persistent disk
-                            resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                           type: string
                       required:
                       - volumeID
                       type: object
                     azureDisk:
-                      description: azureDisk represents an Azure Data Disk mount on
-                        the host and bind mount to the pod.
                       properties:
                         cachingMode:
-                          description: 'cachingMode is the Host Caching mode: None,
-                            Read Only, Read Write.'
                           type: string
                         diskName:
-                          description: diskName is the Name of the data disk in the
-                            blob storage
                           type: string
                         diskURI:
-                          description: diskURI is the URI of data disk in the blob
-                            storage
                           type: string
                         fsType:
-                          description: fsType is Filesystem type to mount. Must be
-                            a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
-                            if unspecified.
                           type: string
                         kind:
-                          description: 'kind expected values are Shared: multiple
-                            blob disks per storage account  Dedicated: single blob
-                            disk per storage account  Managed: azure managed data
-                            disk (only in managed availability set). defaults to shared'
                           type: string
                         readOnly:
-                          description: readOnly Defaults to false (read/write). ReadOnly
-                            here will force the ReadOnly setting in VolumeMounts.
                           type: boolean
                       required:
                       - diskName
                       - diskURI
                       type: object
                     azureFile:
-                      description: azureFile represents an Azure File Service mount
-                        on the host and bind mount to the pod.
                       properties:
                         readOnly:
-                          description: readOnly defaults to false (read/write). ReadOnly
-                            here will force the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretName:
-                          description: secretName is the  name of secret that contains
-                            Azure Storage Account Name and Key
                           type: string
                         shareName:
-                          description: shareName is the azure share Name
                           type: string
                       required:
                       - secretName
                       - shareName
                       type: object
                     cephfs:
-                      description: cephFS represents a Ceph FS mount on the host that
-                        shares a pod's lifetime
                       properties:
                         monitors:
-                          description: 'monitors is Required: Monitors is a collection
-                            of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                           items:
                             type: string
                           type: array
                         path:
-                          description: 'path is Optional: Used as the mounted root,
-                            rather than the full Ceph tree, default is /'
                           type: string
                         readOnly:
-                          description: 'readOnly is Optional: Defaults to false (read/write).
-                            ReadOnly here will force the ReadOnly setting in VolumeMounts.
-                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                           type: boolean
                         secretFile:
-                          description: 'secretFile is Optional: SecretFile is the
-                            path to key ring for User, default is /etc/ceph/user.secret
-                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                           type: string
                         secretRef:
-                          description: 'secretRef is Optional: SecretRef is reference
-                            to the authentication secret for User, default is empty.
-                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                           properties:
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         user:
-                          description: 'user is optional: User is the rados user name,
-                            default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                           type: string
                       required:
                       - monitors
                       type: object
                     cinder:
-                      description: 'cinder represents a cinder volume attached and
-                        mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                       properties:
                         fsType:
-                          description: 'fsType is the filesystem type to mount. Must
-                            be a filesystem type supported by the host operating system.
-                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to
-                            be "ext4" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                           type: string
                         readOnly:
-                          description: 'readOnly defaults to false (read/write). ReadOnly
-                            here will force the ReadOnly setting in VolumeMounts.
-                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                           type: boolean
                         secretRef:
-                          description: 'secretRef is optional: points to a secret
-                            object containing parameters used to connect to OpenStack.'
                           properties:
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         volumeID:
-                          description: 'volumeID used to identify the volume in cinder.
-                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                           type: string
                       required:
                       - volumeID
                       type: object
                     configMap:
-                      description: configMap represents a configMap that should populate
-                        this volume
                       properties:
                         defaultMode:
-                          description: 'defaultMode is optional: mode bits used to
-                            set permissions on created files by default. Must be an
-                            octal value between 0000 and 0777 or a decimal value between
-                            0 and 511. YAML accepts both octal and decimal values,
-                            JSON requires decimal values for mode bits. Defaults to
-                            0644. Directories within the path are not affected by
-                            this setting. This might be in conflict with other options
-                            that affect the file mode, like fsGroup, and the result
-                            can be other mode bits set.'
                           format: int32
                           type: integer
                         items:
-                          description: items if unspecified, each key-value pair in
-                            the Data field of the referenced ConfigMap will be projected
-                            into the volume as a file whose name is the key and content
-                            is the value. If specified, the listed keys will be projected
-                            into the specified paths, and unlisted keys will not be
-                            present. If a key is specified which is not present in
-                            the ConfigMap, the volume setup will error unless it is
-                            marked optional. Paths must be relative and may not contain
-                            the '..' path or start with '..'.
                           items:
-                            description: Maps a string key to a path within a volume.
                             properties:
                               key:
-                                description: key is the key to project.
                                 type: string
                               mode:
-                                description: 'mode is Optional: mode bits used to
-                                  set permissions on this file. Must be an octal value
-                                  between 0000 and 0777 or a decimal value between
-                                  0 and 511. YAML accepts both octal and decimal values,
-                                  JSON requires decimal values for mode bits. If not
-                                  specified, the volume defaultMode will be used.
-                                  This might be in conflict with other options that
-                                  affect the file mode, like fsGroup, and the result
-                                  can be other mode bits set.'
                                 format: int32
                                 type: integer
                               path:
-                                description: path is the relative path of the file
-                                  to map the key to. May not be an absolute path.
-                                  May not contain the path element '..'. May not start
-                                  with the string '..'.
                                 type: string
                             required:
                             - key
@@ -8192,139 +3912,66 @@ spec:
                             type: object
                           type: array
                         name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?'
                           type: string
                         optional:
-                          description: optional specify whether the ConfigMap or its
-                            keys must be defined
                           type: boolean
                       type: object
                       x-kubernetes-map-type: atomic
                     csi:
-                      description: csi (Container Storage Interface) represents ephemeral
-                        storage that is handled by certain external CSI drivers (Beta
-                        feature).
                       properties:
                         driver:
-                          description: driver is the name of the CSI driver that handles
-                            this volume. Consult with your admin for the correct name
-                            as registered in the cluster.
                           type: string
                         fsType:
-                          description: fsType to mount. Ex. "ext4", "xfs", "ntfs".
-                            If not provided, the empty value is passed to the associated
-                            CSI driver which will determine the default filesystem
-                            to apply.
                           type: string
                         nodePublishSecretRef:
-                          description: nodePublishSecretRef is a reference to the
-                            secret object containing sensitive information to pass
-                            to the CSI driver to complete the CSI NodePublishVolume
-                            and NodeUnpublishVolume calls. This field is optional,
-                            and  may be empty if no secret is required. If the secret
-                            object contains more than one secret, all secret references
-                            are passed.
                           properties:
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         readOnly:
-                          description: readOnly specifies a read-only configuration
-                            for the volume. Defaults to false (read/write).
                           type: boolean
                         volumeAttributes:
                           additionalProperties:
                             type: string
-                          description: volumeAttributes stores driver-specific properties
-                            that are passed to the CSI driver. Consult your driver's
-                            documentation for supported values.
                           type: object
                       required:
                       - driver
                       type: object
                     downwardAPI:
-                      description: downwardAPI represents downward API about the pod
-                        that should populate this volume
                       properties:
                         defaultMode:
-                          description: 'Optional: mode bits to use on created files
-                            by default. Must be a Optional: mode bits used to set
-                            permissions on created files by default. Must be an octal
-                            value between 0000 and 0777 or a decimal value between
-                            0 and 511. YAML accepts both octal and decimal values,
-                            JSON requires decimal values for mode bits. Defaults to
-                            0644. Directories within the path are not affected by
-                            this setting. This might be in conflict with other options
-                            that affect the file mode, like fsGroup, and the result
-                            can be other mode bits set.'
                           format: int32
                           type: integer
                         items:
-                          description: Items is a list of downward API volume file
                           items:
-                            description: DownwardAPIVolumeFile represents information
-                              to create the file containing the pod field
                             properties:
                               fieldRef:
-                                description: 'Required: Selects a field of the pod:
-                                  only annotations, labels, name and namespace are
-                                  supported.'
                                 properties:
                                   apiVersion:
-                                    description: Version of the schema the FieldPath
-                                      is written in terms of, defaults to "v1".
                                     type: string
                                   fieldPath:
-                                    description: Path of the field to select in the
-                                      specified API version.
                                     type: string
                                 required:
                                 - fieldPath
                                 type: object
                                 x-kubernetes-map-type: atomic
                               mode:
-                                description: 'Optional: mode bits used to set permissions
-                                  on this file, must be an octal value between 0000
-                                  and 0777 or a decimal value between 0 and 511. YAML
-                                  accepts both octal and decimal values, JSON requires
-                                  decimal values for mode bits. If not specified,
-                                  the volume defaultMode will be used. This might
-                                  be in conflict with other options that affect the
-                                  file mode, like fsGroup, and the result can be other
-                                  mode bits set.'
                                 format: int32
                                 type: integer
                               path:
-                                description: 'Required: Path is  the relative path
-                                  name of the file to be created. Must not be absolute
-                                  or contain the ''..'' path. Must be utf-8 encoded.
-                                  The first item of the relative path must not start
-                                  with ''..'''
                                 type: string
                               resourceFieldRef:
-                                description: 'Selects a resource of the container:
-                                  only resources limits and requests (limits.cpu,
-                                  limits.memory, requests.cpu and requests.memory)
-                                  are currently supported.'
                                 properties:
                                   containerName:
-                                    description: 'Container name: required for volumes,
-                                      optional for env vars'
                                     type: string
                                   divisor:
                                     anyOf:
                                     - type: integer
                                     - type: string
-                                    description: Specifies the output format of the
-                                      exposed resources, defaults to "1"
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                   resource:
-                                    description: 'Required: resource to select'
                                     type: string
                                 required:
                                 - resource
@@ -8336,114 +3983,35 @@ spec:
                           type: array
                       type: object
                     emptyDir:
-                      description: 'emptyDir represents a temporary directory that
-                        shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                       properties:
                         medium:
-                          description: 'medium represents what type of storage medium
-                            should back this directory. The default is "" which means
-                            to use the node''s default medium. Must be an empty string
-                            (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                           type: string
                         sizeLimit:
                           anyOf:
                           - type: integer
                           - type: string
-                          description: 'sizeLimit is the total amount of local storage
-                            required for this EmptyDir volume. The size limit is also
-                            applicable for memory medium. The maximum usage on memory
-                            medium EmptyDir would be the minimum value between the
-                            SizeLimit specified here and the sum of memory limits
-                            of all containers in a pod. The default is nil which means
-                            that the limit is undefined. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                       type: object
                     ephemeral:
-                      description: "ephemeral represents a volume that is handled
-                        by a cluster storage driver. The volume's lifecycle is tied
-                        to the pod that defines it - it will be created before the
-                        pod starts, and deleted when the pod is removed. \n Use this
-                        if: a) the volume is only needed while the pod runs, b) features
-                        of normal volumes like restoring from snapshot or capacity
-                        tracking are needed, c) the storage driver is specified through
-                        a storage class, and d) the storage driver supports dynamic
-                        volume provisioning through a PersistentVolumeClaim (see EphemeralVolumeSource
-                        for more information on the connection between this volume
-                        type and PersistentVolumeClaim). \n Use PersistentVolumeClaim
-                        or one of the vendor-specific APIs for volumes that persist
-                        for longer than the lifecycle of an individual pod. \n Use
-                        CSI for light-weight local ephemeral volumes if the CSI driver
-                        is meant to be used that way - see the documentation of the
-                        driver for more information. \n A pod can use both types of
-                        ephemeral volumes and persistent volumes at the same time."
                       properties:
                         volumeClaimTemplate:
-                          description: "Will be used to create a stand-alone PVC to
-                            provision the volume. The pod in which this EphemeralVolumeSource
-                            is embedded will be the owner of the PVC, i.e. the PVC
-                            will be deleted together with the pod.  The name of the
-                            PVC will be `<pod name>-<volume name>` where `<volume
-                            name>` is the name from the `PodSpec.Volumes` array entry.
-                            Pod validation will reject the pod if the concatenated
-                            name is not valid for a PVC (for example, too long). \n
-                            An existing PVC with that name that is not owned by the
-                            pod will *not* be used for the pod to avoid using an unrelated
-                            volume by mistake. Starting the pod is then blocked until
-                            the unrelated PVC is removed. If such a pre-created PVC
-                            is meant to be used by the pod, the PVC has to updated
-                            with an owner reference to the pod once the pod exists.
-                            Normally this should not be necessary, but it may be useful
-                            when manually reconstructing a broken cluster. \n This
-                            field is read-only and no changes will be made by Kubernetes
-                            to the PVC after it has been created. \n Required, must
-                            not be nil."
                           properties:
                             metadata:
-                              description: May contain labels and annotations that
-                                will be copied into the PVC when creating it. No other
-                                fields are allowed and will be rejected during validation.
                               type: object
                             spec:
-                              description: The specification for the PersistentVolumeClaim.
-                                The entire content is copied unchanged into the PVC
-                                that gets created from this template. The same fields
-                                as in a PersistentVolumeClaim are also valid here.
                               properties:
                                 accessModes:
-                                  description: 'accessModes contains the desired access
-                                    modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                                   items:
                                     type: string
                                   type: array
                                 dataSource:
-                                  description: 'dataSource field can be used to specify
-                                    either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                                    * An existing PVC (PersistentVolumeClaim) If the
-                                    provisioner or an external controller can support
-                                    the specified data source, it will create a new
-                                    volume based on the contents of the specified
-                                    data source. When the AnyVolumeDataSource feature
-                                    gate is enabled, dataSource contents will be copied
-                                    to dataSourceRef, and dataSourceRef contents will
-                                    be copied to dataSource when dataSourceRef.namespace
-                                    is not specified. If the namespace is specified,
-                                    then dataSourceRef will not be copied to dataSource.'
                                   properties:
                                     apiGroup:
-                                      description: APIGroup is the group for the resource
-                                        being referenced. If APIGroup is not specified,
-                                        the specified Kind must be in the core API
-                                        group. For any other third-party types, APIGroup
-                                        is required.
                                       type: string
                                     kind:
-                                      description: Kind is the type of resource being
-                                        referenced
                                       type: string
                                     name:
-                                      description: Name is the name of resource being
-                                        referenced
                                       type: string
                                   required:
                                   - kind
@@ -8451,94 +4019,25 @@ spec:
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 dataSourceRef:
-                                  description: 'dataSourceRef specifies the object
-                                    from which to populate the volume with data, if
-                                    a non-empty volume is desired. This may be any
-                                    object from a non-empty API group (non core object)
-                                    or a PersistentVolumeClaim object. When this field
-                                    is specified, volume binding will only succeed
-                                    if the type of the specified object matches some
-                                    installed volume populator or dynamic provisioner.
-                                    This field will replace the functionality of the
-                                    dataSource field and as such if both fields are
-                                    non-empty, they must have the same value. For
-                                    backwards compatibility, when namespace isn''t
-                                    specified in dataSourceRef, both fields (dataSource
-                                    and dataSourceRef) will be set to the same value
-                                    automatically if one of them is empty and the
-                                    other is non-empty. When namespace is specified
-                                    in dataSourceRef, dataSource isn''t set to the
-                                    same value and must be empty. There are three
-                                    important differences between dataSource and dataSourceRef:
-                                    * While dataSource only allows two specific types
-                                    of objects, dataSourceRef allows any non-core
-                                    object, as well as PersistentVolumeClaim objects.
-                                    * While dataSource ignores disallowed values (dropping
-                                    them), dataSourceRef preserves all values, and
-                                    generates an error if a disallowed value is specified.
-                                    * While dataSource only allows local objects,
-                                    dataSourceRef allows objects in any namespaces.
-                                    (Beta) Using this field requires the AnyVolumeDataSource
-                                    feature gate to be enabled. (Alpha) Using the
-                                    namespace field of dataSourceRef requires the
-                                    CrossNamespaceVolumeDataSource feature gate to
-                                    be enabled.'
                                   properties:
                                     apiGroup:
-                                      description: APIGroup is the group for the resource
-                                        being referenced. If APIGroup is not specified,
-                                        the specified Kind must be in the core API
-                                        group. For any other third-party types, APIGroup
-                                        is required.
                                       type: string
                                     kind:
-                                      description: Kind is the type of resource being
-                                        referenced
                                       type: string
                                     name:
-                                      description: Name is the name of resource being
-                                        referenced
                                       type: string
                                     namespace:
-                                      description: Namespace is the namespace of resource
-                                        being referenced Note that when a namespace
-                                        is specified, a gateway.networking.k8s.io/ReferenceGrant
-                                        object is required in the referent namespace
-                                        to allow that namespace's owner to accept
-                                        the reference. See the ReferenceGrant documentation
-                                        for details. (Alpha) This field requires the
-                                        CrossNamespaceVolumeDataSource feature gate
-                                        to be enabled.
                                       type: string
                                   required:
                                   - kind
                                   - name
                                   type: object
                                 resources:
-                                  description: 'resources represents the minimum resources
-                                    the volume should have. If RecoverVolumeExpansionFailure
-                                    feature is enabled users are allowed to specify
-                                    resource requirements that are lower than previous
-                                    value but must still be higher than capacity recorded
-                                    in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                                   properties:
                                     claims:
-                                      description: "Claims lists the names of resources,
-                                        defined in spec.resourceClaims, that are used
-                                        by this container. \n This is an alpha field
-                                        and requires enabling the DynamicResourceAllocation
-                                        feature gate. \n This field is immutable.
-                                        It can only be set for containers."
                                       items:
-                                        description: ResourceClaim references one
-                                          entry in PodSpec.ResourceClaims.
                                         properties:
                                           name:
-                                            description: Name must match the name
-                                              of one entry in pod.spec.resourceClaims
-                                              of the Pod where this field is used.
-                                              It makes that resource available inside
-                                              a container.
                                             type: string
                                         required:
                                         - name
@@ -8554,8 +4053,6 @@ spec:
                                         - type: string
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
-                                      description: 'Limits describes the maximum amount
-                                        of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                       type: object
                                     requests:
                                       additionalProperties:
@@ -8564,46 +4061,18 @@ spec:
                                         - type: string
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
-                                      description: 'Requests describes the minimum
-                                        amount of compute resources required. If Requests
-                                        is omitted for a container, it defaults to
-                                        Limits if that is explicitly specified, otherwise
-                                        to an implementation-defined value. Requests
-                                        cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                       type: object
                                   type: object
                                 selector:
-                                  description: selector is a label query over volumes
-                                    to consider for binding.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
                                       items:
-                                        description: A label selector requirement
-                                          is a selector that contains values, a key,
-                                          and an operator that relates the key and
-                                          values.
                                         properties:
                                           key:
-                                            description: key is the label key that
-                                              the selector applies to.
                                             type: string
                                           operator:
-                                            description: operator represents a key's
-                                              relationship to a set of values. Valid
-                                              operators are In, NotIn, Exists and
-                                              DoesNotExist.
                                             type: string
                                           values:
-                                            description: values is an array of string
-                                              values. If the operator is In or NotIn,
-                                              the values array must be non-empty.
-                                              If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This
-                                              array is replaced during a strategic
-                                              merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -8615,28 +4084,14 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: matchLabels is a map of {key,value}
-                                        pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions,
-                                        whose key field is "key", the operator is
-                                        "In", and the values array contains only "value".
-                                        The requirements are ANDed.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 storageClassName:
-                                  description: 'storageClassName is the name of the
-                                    StorageClass required by the claim. More info:
-                                    https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                                   type: string
                                 volumeMode:
-                                  description: volumeMode defines what type of volume
-                                    is required by the claim. Value of Filesystem
-                                    is implied when not included in claim spec.
                                   type: string
                                 volumeName:
-                                  description: volumeName is the binding reference
-                                    to the PersistentVolume backing this claim.
                                   type: string
                               type: object
                           required:
@@ -8644,74 +4099,38 @@ spec:
                           type: object
                       type: object
                     fc:
-                      description: fc represents a Fibre Channel resource that is
-                        attached to a kubelet's host machine and then exposed to the
-                        pod.
                       properties:
                         fsType:
-                          description: 'fsType is the filesystem type to mount. Must
-                            be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
-                            if unspecified. TODO: how do we prevent errors in the
-                            filesystem from compromising the machine'
                           type: string
                         lun:
-                          description: 'lun is Optional: FC target lun number'
                           format: int32
                           type: integer
                         readOnly:
-                          description: 'readOnly is Optional: Defaults to false (read/write).
-                            ReadOnly here will force the ReadOnly setting in VolumeMounts.'
                           type: boolean
                         targetWWNs:
-                          description: 'targetWWNs is Optional: FC target worldwide
-                            names (WWNs)'
                           items:
                             type: string
                           type: array
                         wwids:
-                          description: 'wwids Optional: FC volume world wide identifiers
-                            (wwids) Either wwids or combination of targetWWNs and
-                            lun must be set, but not both simultaneously.'
                           items:
                             type: string
                           type: array
                       type: object
                     flexVolume:
-                      description: flexVolume represents a generic volume resource
-                        that is provisioned/attached using an exec based plugin.
                       properties:
                         driver:
-                          description: driver is the name of the driver to use for
-                            this volume.
                           type: string
                         fsType:
-                          description: fsType is the filesystem type to mount. Must
-                            be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". The default filesystem depends
-                            on FlexVolume script.
                           type: string
                         options:
                           additionalProperties:
                             type: string
-                          description: 'options is Optional: this field holds extra
-                            command options if any.'
                           type: object
                         readOnly:
-                          description: 'readOnly is Optional: defaults to false (read/write).
-                            ReadOnly here will force the ReadOnly setting in VolumeMounts.'
                           type: boolean
                         secretRef:
-                          description: 'secretRef is Optional: secretRef is reference
-                            to the secret object containing sensitive information
-                            to pass to the plugin scripts. This may be empty if no
-                            secret object is specified. If the secret object contains
-                            more than one secret, all secrets are passed to the plugin
-                            scripts.'
                           properties:
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
@@ -8719,184 +4138,88 @@ spec:
                       - driver
                       type: object
                     flocker:
-                      description: flocker represents a Flocker volume attached to
-                        a kubelet's host machine. This depends on the Flocker control
-                        service being running
                       properties:
                         datasetName:
-                          description: datasetName is Name of the dataset stored as
-                            metadata -> name on the dataset for Flocker should be
-                            considered as deprecated
                           type: string
                         datasetUUID:
-                          description: datasetUUID is the UUID of the dataset. This
-                            is unique identifier of a Flocker dataset
                           type: string
                       type: object
                     gcePersistentDisk:
-                      description: 'gcePersistentDisk represents a GCE Disk resource
-                        that is attached to a kubelet''s host machine and then exposed
-                        to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                       properties:
                         fsType:
-                          description: 'fsType is filesystem type of the volume that
-                            you want to mount. Tip: Ensure that the filesystem type
-                            is supported by the host operating system. Examples: "ext4",
-                            "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                            TODO: how do we prevent errors in the filesystem from
-                            compromising the machine'
                           type: string
                         partition:
-                          description: 'partition is the partition in the volume that
-                            you want to mount. If omitted, the default is to mount
-                            by volume name. Examples: For volume /dev/sda1, you specify
-                            the partition as "1". Similarly, the volume partition
-                            for /dev/sda is "0" (or you can leave the property empty).
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                           format: int32
                           type: integer
                         pdName:
-                          description: 'pdName is unique name of the PD resource in
-                            GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                           type: string
                         readOnly:
-                          description: 'readOnly here will force the ReadOnly setting
-                            in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                           type: boolean
                       required:
                       - pdName
                       type: object
                     gitRepo:
-                      description: 'gitRepo represents a git repository at a particular
-                        revision. DEPRECATED: GitRepo is deprecated. To provision
-                        a container with a git repo, mount an EmptyDir into an InitContainer
-                        that clones the repo using git, then mount the EmptyDir into
-                        the Pod''s container.'
                       properties:
                         directory:
-                          description: directory is the target directory name. Must
-                            not contain or start with '..'.  If '.' is supplied, the
-                            volume directory will be the git repository.  Otherwise,
-                            if specified, the volume will contain the git repository
-                            in the subdirectory with the given name.
                           type: string
                         repository:
-                          description: repository is the URL
                           type: string
                         revision:
-                          description: revision is the commit hash for the specified
-                            revision.
                           type: string
                       required:
                       - repository
                       type: object
                     glusterfs:
-                      description: 'glusterfs represents a Glusterfs mount on the
-                        host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
                       properties:
                         endpoints:
-                          description: 'endpoints is the endpoint name that details
-                            Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                           type: string
                         path:
-                          description: 'path is the Glusterfs volume path. More info:
-                            https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                           type: string
                         readOnly:
-                          description: 'readOnly here will force the Glusterfs volume
-                            to be mounted with read-only permissions. Defaults to
-                            false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                           type: boolean
                       required:
                       - endpoints
                       - path
                       type: object
                     hostPath:
-                      description: 'hostPath represents a pre-existing file or directory
-                        on the host machine that is directly exposed to the container.
-                        This is generally used for system agents or other privileged
-                        things that are allowed to see the host machine. Most containers
-                        will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                        --- TODO(jonesdl) We need to restrict who can use host directory
-                        mounts and who can/can not mount host directories as read/write.'
                       properties:
                         path:
-                          description: 'path of the directory on the host. If the
-                            path is a symlink, it will follow the link to the real
-                            path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                           type: string
                         type:
-                          description: 'type for HostPath Volume Defaults to "" More
-                            info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                           type: string
                       required:
                       - path
                       type: object
                     iscsi:
-                      description: 'iscsi represents an ISCSI Disk resource that is
-                        attached to a kubelet''s host machine and then exposed to
-                        the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
                       properties:
                         chapAuthDiscovery:
-                          description: chapAuthDiscovery defines whether support iSCSI
-                            Discovery CHAP authentication
                           type: boolean
                         chapAuthSession:
-                          description: chapAuthSession defines whether support iSCSI
-                            Session CHAP authentication
                           type: boolean
                         fsType:
-                          description: 'fsType is the filesystem type of the volume
-                            that you want to mount. Tip: Ensure that the filesystem
-                            type is supported by the host operating system. Examples:
-                            "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
-                            if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                            TODO: how do we prevent errors in the filesystem from
-                            compromising the machine'
                           type: string
                         initiatorName:
-                          description: initiatorName is the custom iSCSI Initiator
-                            Name. If initiatorName is specified with iscsiInterface
-                            simultaneously, new iSCSI interface <target portal>:<volume
-                            name> will be created for the connection.
                           type: string
                         iqn:
-                          description: iqn is the target iSCSI Qualified Name.
                           type: string
                         iscsiInterface:
-                          description: iscsiInterface is the interface Name that uses
-                            an iSCSI transport. Defaults to 'default' (tcp).
                           type: string
                         lun:
-                          description: lun represents iSCSI Target Lun number.
                           format: int32
                           type: integer
                         portals:
-                          description: portals is the iSCSI Target Portal List. The
-                            portal is either an IP or ip_addr:port if the port is
-                            other than default (typically TCP ports 860 and 3260).
                           items:
                             type: string
                           type: array
                         readOnly:
-                          description: readOnly here will force the ReadOnly setting
-                            in VolumeMounts. Defaults to false.
                           type: boolean
                         secretRef:
-                          description: secretRef is the CHAP Secret for iSCSI target
-                            and initiator authentication
                           properties:
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         targetPortal:
-                          description: targetPortal is iSCSI Target Portal. The Portal
-                            is either an IP or ip_addr:port if the port is other than
-                            default (typically TCP ports 860 and 3260).
                           type: string
                       required:
                       - iqn
@@ -8904,148 +4227,67 @@ spec:
                       - targetPortal
                       type: object
                     name:
-                      description: 'name of the volume. Must be a DNS_LABEL and unique
-                        within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                       type: string
                     nfs:
-                      description: 'nfs represents an NFS mount on the host that shares
-                        a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                       properties:
                         path:
-                          description: 'path that is exported by the NFS server. More
-                            info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                           type: string
                         readOnly:
-                          description: 'readOnly here will force the NFS export to
-                            be mounted with read-only permissions. Defaults to false.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                           type: boolean
                         server:
-                          description: 'server is the hostname or IP address of the
-                            NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                           type: string
                       required:
                       - path
                       - server
                       type: object
                     persistentVolumeClaim:
-                      description: 'persistentVolumeClaimVolumeSource represents a
-                        reference to a PersistentVolumeClaim in the same namespace.
-                        More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                       properties:
                         claimName:
-                          description: 'claimName is the name of a PersistentVolumeClaim
-                            in the same namespace as the pod using this volume. More
-                            info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                           type: string
                         readOnly:
-                          description: readOnly Will force the ReadOnly setting in
-                            VolumeMounts. Default false.
                           type: boolean
                       required:
                       - claimName
                       type: object
                     photonPersistentDisk:
-                      description: photonPersistentDisk represents a PhotonController
-                        persistent disk attached and mounted on kubelets host machine
                       properties:
                         fsType:
-                          description: fsType is the filesystem type to mount. Must
-                            be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
-                            if unspecified.
                           type: string
                         pdID:
-                          description: pdID is the ID that identifies Photon Controller
-                            persistent disk
                           type: string
                       required:
                       - pdID
                       type: object
                     portworxVolume:
-                      description: portworxVolume represents a portworx volume attached
-                        and mounted on kubelets host machine
                       properties:
                         fsType:
-                          description: fSType represents the filesystem type to mount
-                            Must be a filesystem type supported by the host operating
-                            system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4"
-                            if unspecified.
                           type: string
                         readOnly:
-                          description: readOnly defaults to false (read/write). ReadOnly
-                            here will force the ReadOnly setting in VolumeMounts.
                           type: boolean
                         volumeID:
-                          description: volumeID uniquely identifies a Portworx volume
                           type: string
                       required:
                       - volumeID
                       type: object
                     projected:
-                      description: projected items for all in one resources secrets,
-                        configmaps, and downward API
                       properties:
                         defaultMode:
-                          description: defaultMode are the mode bits used to set permissions
-                            on created files by default. Must be an octal value between
-                            0000 and 0777 or a decimal value between 0 and 511. YAML
-                            accepts both octal and decimal values, JSON requires decimal
-                            values for mode bits. Directories within the path are
-                            not affected by this setting. This might be in conflict
-                            with other options that affect the file mode, like fsGroup,
-                            and the result can be other mode bits set.
                           format: int32
                           type: integer
                         sources:
-                          description: sources is the list of volume projections
                           items:
-                            description: Projection that may be projected along with
-                              other supported volume types
                             properties:
                               configMap:
-                                description: configMap information about the configMap
-                                  data to project
                                 properties:
                                   items:
-                                    description: items if unspecified, each key-value
-                                      pair in the Data field of the referenced ConfigMap
-                                      will be projected into the volume as a file
-                                      whose name is the key and content is the value.
-                                      If specified, the listed keys will be projected
-                                      into the specified paths, and unlisted keys
-                                      will not be present. If a key is specified which
-                                      is not present in the ConfigMap, the volume
-                                      setup will error unless it is marked optional.
-                                      Paths must be relative and may not contain the
-                                      '..' path or start with '..'.
                                     items:
-                                      description: Maps a string key to a path within
-                                        a volume.
                                       properties:
                                         key:
-                                          description: key is the key to project.
                                           type: string
                                         mode:
-                                          description: 'mode is Optional: mode bits
-                                            used to set permissions on this file.
-                                            Must be an octal value between 0000 and
-                                            0777 or a decimal value between 0 and
-                                            511. YAML accepts both octal and decimal
-                                            values, JSON requires decimal values for
-                                            mode bits. If not specified, the volume
-                                            defaultMode will be used. This might be
-                                            in conflict with other options that affect
-                                            the file mode, like fsGroup, and the result
-                                            can be other mode bits set.'
                                           format: int32
                                           type: integer
                                         path:
-                                          description: path is the relative path of
-                                            the file to map the key to. May not be
-                                            an absolute path. May not contain the
-                                            path element '..'. May not start with
-                                            the string '..'.
                                           type: string
                                       required:
                                       - key
@@ -9053,91 +4295,42 @@ spec:
                                       type: object
                                     type: array
                                   name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
                                     type: string
                                   optional:
-                                    description: optional specify whether the ConfigMap
-                                      or its keys must be defined
                                     type: boolean
                                 type: object
                                 x-kubernetes-map-type: atomic
                               downwardAPI:
-                                description: downwardAPI information about the downwardAPI
-                                  data to project
                                 properties:
                                   items:
-                                    description: Items is a list of DownwardAPIVolume
-                                      file
                                     items:
-                                      description: DownwardAPIVolumeFile represents
-                                        information to create the file containing
-                                        the pod field
                                       properties:
                                         fieldRef:
-                                          description: 'Required: Selects a field
-                                            of the pod: only annotations, labels,
-                                            name and namespace are supported.'
                                           properties:
                                             apiVersion:
-                                              description: Version of the schema the
-                                                FieldPath is written in terms of,
-                                                defaults to "v1".
                                               type: string
                                             fieldPath:
-                                              description: Path of the field to select
-                                                in the specified API version.
                                               type: string
                                           required:
                                           - fieldPath
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         mode:
-                                          description: 'Optional: mode bits used to
-                                            set permissions on this file, must be
-                                            an octal value between 0000 and 0777 or
-                                            a decimal value between 0 and 511. YAML
-                                            accepts both octal and decimal values,
-                                            JSON requires decimal values for mode
-                                            bits. If not specified, the volume defaultMode
-                                            will be used. This might be in conflict
-                                            with other options that affect the file
-                                            mode, like fsGroup, and the result can
-                                            be other mode bits set.'
                                           format: int32
                                           type: integer
                                         path:
-                                          description: 'Required: Path is  the relative
-                                            path name of the file to be created. Must
-                                            not be absolute or contain the ''..''
-                                            path. Must be utf-8 encoded. The first
-                                            item of the relative path must not start
-                                            with ''..'''
                                           type: string
                                         resourceFieldRef:
-                                          description: 'Selects a resource of the
-                                            container: only resources limits and requests
-                                            (limits.cpu, limits.memory, requests.cpu
-                                            and requests.memory) are currently supported.'
                                           properties:
                                             containerName:
-                                              description: 'Container name: required
-                                                for volumes, optional for env vars'
                                               type: string
                                             divisor:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Specifies the output format
-                                                of the exposed resources, defaults
-                                                to "1"
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
                                             resource:
-                                              description: 'Required: resource to
-                                                select'
                                               type: string
                                           required:
                                           - resource
@@ -9149,48 +4342,16 @@ spec:
                                     type: array
                                 type: object
                               secret:
-                                description: secret information about the secret data
-                                  to project
                                 properties:
                                   items:
-                                    description: items if unspecified, each key-value
-                                      pair in the Data field of the referenced Secret
-                                      will be projected into the volume as a file
-                                      whose name is the key and content is the value.
-                                      If specified, the listed keys will be projected
-                                      into the specified paths, and unlisted keys
-                                      will not be present. If a key is specified which
-                                      is not present in the Secret, the volume setup
-                                      will error unless it is marked optional. Paths
-                                      must be relative and may not contain the '..'
-                                      path or start with '..'.
                                     items:
-                                      description: Maps a string key to a path within
-                                        a volume.
                                       properties:
                                         key:
-                                          description: key is the key to project.
                                           type: string
                                         mode:
-                                          description: 'mode is Optional: mode bits
-                                            used to set permissions on this file.
-                                            Must be an octal value between 0000 and
-                                            0777 or a decimal value between 0 and
-                                            511. YAML accepts both octal and decimal
-                                            values, JSON requires decimal values for
-                                            mode bits. If not specified, the volume
-                                            defaultMode will be used. This might be
-                                            in conflict with other options that affect
-                                            the file mode, like fsGroup, and the result
-                                            can be other mode bits set.'
                                           format: int32
                                           type: integer
                                         path:
-                                          description: path is the relative path of
-                                            the file to map the key to. May not be
-                                            an absolute path. May not contain the
-                                            path element '..'. May not start with
-                                            the string '..'.
                                           type: string
                                       required:
                                       - key
@@ -9198,45 +4359,19 @@ spec:
                                       type: object
                                     type: array
                                   name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
                                     type: string
                                   optional:
-                                    description: optional field specify whether the
-                                      Secret or its key must be defined
                                     type: boolean
                                 type: object
                                 x-kubernetes-map-type: atomic
                               serviceAccountToken:
-                                description: serviceAccountToken is information about
-                                  the serviceAccountToken data to project
                                 properties:
                                   audience:
-                                    description: audience is the intended audience
-                                      of the token. A recipient of a token must identify
-                                      itself with an identifier specified in the audience
-                                      of the token, and otherwise should reject the
-                                      token. The audience defaults to the identifier
-                                      of the apiserver.
                                     type: string
                                   expirationSeconds:
-                                    description: expirationSeconds is the requested
-                                      duration of validity of the service account
-                                      token. As the token approaches expiration, the
-                                      kubelet volume plugin will proactively rotate
-                                      the service account token. The kubelet will
-                                      start trying to rotate the token if the token
-                                      is older than 80 percent of its time to live
-                                      or if the token is older than 24 hours.Defaults
-                                      to 1 hour and must be at least 10 minutes.
                                     format: int64
                                     type: integer
                                   path:
-                                    description: path is the path relative to the
-                                      mount point of the file to project the token
-                                      into.
                                     type: string
                                 required:
                                 - path
@@ -9245,148 +4380,76 @@ spec:
                           type: array
                       type: object
                     quobyte:
-                      description: quobyte represents a Quobyte mount on the host
-                        that shares a pod's lifetime
                       properties:
                         group:
-                          description: group to map volume access to Default is no
-                            group
                           type: string
                         readOnly:
-                          description: readOnly here will force the Quobyte volume
-                            to be mounted with read-only permissions. Defaults to
-                            false.
                           type: boolean
                         registry:
-                          description: registry represents a single or multiple Quobyte
-                            Registry services specified as a string as host:port pair
-                            (multiple entries are separated with commas) which acts
-                            as the central registry for volumes
                           type: string
                         tenant:
-                          description: tenant owning the given Quobyte volume in the
-                            Backend Used with dynamically provisioned Quobyte volumes,
-                            value is set by the plugin
                           type: string
                         user:
-                          description: user to map volume access to Defaults to serivceaccount
-                            user
                           type: string
                         volume:
-                          description: volume is a string that references an already
-                            created Quobyte volume by name.
                           type: string
                       required:
                       - registry
                       - volume
                       type: object
                     rbd:
-                      description: 'rbd represents a Rados Block Device mount on the
-                        host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
                       properties:
                         fsType:
-                          description: 'fsType is the filesystem type of the volume
-                            that you want to mount. Tip: Ensure that the filesystem
-                            type is supported by the host operating system. Examples:
-                            "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
-                            if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                            TODO: how do we prevent errors in the filesystem from
-                            compromising the machine'
                           type: string
                         image:
-                          description: 'image is the rados image name. More info:
-                            https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                           type: string
                         keyring:
-                          description: 'keyring is the path to key ring for RBDUser.
-                            Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                           type: string
                         monitors:
-                          description: 'monitors is a collection of Ceph monitors.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                           items:
                             type: string
                           type: array
                         pool:
-                          description: 'pool is the rados pool name. Default is rbd.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                           type: string
                         readOnly:
-                          description: 'readOnly here will force the ReadOnly setting
-                            in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                           type: boolean
                         secretRef:
-                          description: 'secretRef is name of the authentication secret
-                            for RBDUser. If provided overrides keyring. Default is
-                            nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                           properties:
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         user:
-                          description: 'user is the rados user name. Default is admin.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                           type: string
                       required:
                       - image
                       - monitors
                       type: object
                     scaleIO:
-                      description: scaleIO represents a ScaleIO persistent volume
-                        attached and mounted on Kubernetes nodes.
                       properties:
                         fsType:
-                          description: fsType is the filesystem type to mount. Must
-                            be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". Default is "xfs".
                           type: string
                         gateway:
-                          description: gateway is the host address of the ScaleIO
-                            API Gateway.
                           type: string
                         protectionDomain:
-                          description: protectionDomain is the name of the ScaleIO
-                            Protection Domain for the configured storage.
                           type: string
                         readOnly:
-                          description: readOnly Defaults to false (read/write). ReadOnly
-                            here will force the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretRef:
-                          description: secretRef references to the secret for ScaleIO
-                            user and other sensitive information. If this is not provided,
-                            Login operation will fail.
                           properties:
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         sslEnabled:
-                          description: sslEnabled Flag enable/disable SSL communication
-                            with Gateway, default false
                           type: boolean
                         storageMode:
-                          description: storageMode indicates whether the storage for
-                            a volume should be ThickProvisioned or ThinProvisioned.
-                            Default is ThinProvisioned.
                           type: string
                         storagePool:
-                          description: storagePool is the ScaleIO Storage Pool associated
-                            with the protection domain.
                           type: string
                         system:
-                          description: system is the name of the storage system as
-                            configured in ScaleIO.
                           type: string
                         volumeName:
-                          description: volumeName is the name of a volume already
-                            created in the ScaleIO system that is associated with
-                            this volume source.
                           type: string
                       required:
                       - gateway
@@ -9394,54 +4457,19 @@ spec:
                       - system
                       type: object
                     secret:
-                      description: 'secret represents a secret that should populate
-                        this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                       properties:
                         defaultMode:
-                          description: 'defaultMode is Optional: mode bits used to
-                            set permissions on created files by default. Must be an
-                            octal value between 0000 and 0777 or a decimal value between
-                            0 and 511. YAML accepts both octal and decimal values,
-                            JSON requires decimal values for mode bits. Defaults to
-                            0644. Directories within the path are not affected by
-                            this setting. This might be in conflict with other options
-                            that affect the file mode, like fsGroup, and the result
-                            can be other mode bits set.'
                           format: int32
                           type: integer
                         items:
-                          description: items If unspecified, each key-value pair in
-                            the Data field of the referenced Secret will be projected
-                            into the volume as a file whose name is the key and content
-                            is the value. If specified, the listed keys will be projected
-                            into the specified paths, and unlisted keys will not be
-                            present. If a key is specified which is not present in
-                            the Secret, the volume setup will error unless it is marked
-                            optional. Paths must be relative and may not contain the
-                            '..' path or start with '..'.
                           items:
-                            description: Maps a string key to a path within a volume.
                             properties:
                               key:
-                                description: key is the key to project.
                                 type: string
                               mode:
-                                description: 'mode is Optional: mode bits used to
-                                  set permissions on this file. Must be an octal value
-                                  between 0000 and 0777 or a decimal value between
-                                  0 and 511. YAML accepts both octal and decimal values,
-                                  JSON requires decimal values for mode bits. If not
-                                  specified, the volume defaultMode will be used.
-                                  This might be in conflict with other options that
-                                  affect the file mode, like fsGroup, and the result
-                                  can be other mode bits set.'
                                 format: int32
                                 type: integer
                               path:
-                                description: path is the relative path of the file
-                                  to map the key to. May not be an absolute path.
-                                  May not contain the path element '..'. May not start
-                                  with the string '..'.
                                 type: string
                             required:
                             - key
@@ -9449,76 +4477,36 @@ spec:
                             type: object
                           type: array
                         optional:
-                          description: optional field specify whether the Secret or
-                            its keys must be defined
                           type: boolean
                         secretName:
-                          description: 'secretName is the name of the secret in the
-                            pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                           type: string
                       type: object
                     storageos:
-                      description: storageOS represents a StorageOS volume attached
-                        and mounted on Kubernetes nodes.
                       properties:
                         fsType:
-                          description: fsType is the filesystem type to mount. Must
-                            be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
-                            if unspecified.
                           type: string
                         readOnly:
-                          description: readOnly defaults to false (read/write). ReadOnly
-                            here will force the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretRef:
-                          description: secretRef specifies the secret to use for obtaining
-                            the StorageOS API credentials.  If not specified, default
-                            values will be attempted.
                           properties:
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         volumeName:
-                          description: volumeName is the human-readable name of the
-                            StorageOS volume.  Volume names are only unique within
-                            a namespace.
                           type: string
                         volumeNamespace:
-                          description: volumeNamespace specifies the scope of the
-                            volume within StorageOS.  If no namespace is specified
-                            then the Pod's namespace will be used.  This allows the
-                            Kubernetes name scoping to be mirrored within StorageOS
-                            for tighter integration. Set VolumeName to any name to
-                            override the default behaviour. Set to "default" if you
-                            are not using namespaces within StorageOS. Namespaces
-                            that do not pre-exist within StorageOS will be created.
                           type: string
                       type: object
                     vsphereVolume:
-                      description: vsphereVolume represents a vSphere volume attached
-                        and mounted on kubelets host machine
                       properties:
                         fsType:
-                          description: fsType is filesystem type to mount. Must be
-                            a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
-                            if unspecified.
                           type: string
                         storagePolicyID:
-                          description: storagePolicyID is the storage Policy Based
-                            Management (SPBM) profile ID associated with the StoragePolicyName.
                           type: string
                         storagePolicyName:
-                          description: storagePolicyName is the storage Policy Based
-                            Management (SPBM) profile name.
                           type: string
                         volumePath:
-                          description: volumePath is the path that identifies vSphere
-                            volume vmdk
                           type: string
                       required:
                       - volumePath
@@ -9557,114 +4545,60 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: LogsInstance controls an individual logs instance within a Grafana
-          Agent deployment.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           spec:
-            description: Spec holds the specification of the desired behavior for
-              the logs instance.
             properties:
               additionalScrapeConfigs:
-                description: "AdditionalScrapeConfigs allows specifying a key of a
-                  Secret containing additional Grafana Agent logging scrape configurations.
-                  Scrape configurations specified are appended to the configurations
-                  generated by the Grafana Agent Operator. \n Job configurations specified
-                  must have the form as specified in the official Promtail documentation:
-                  \n https://grafana.com/docs/loki/latest/clients/promtail/configuration/#scrape_configs
-                  \n As scrape configs are appended, the user is responsible to make
-                  sure it is valid. Note that using this feature may expose the possibility
-                  to break upgrades of Grafana Agent. It is advised to review both
-                  Grafana Agent and Promtail release notes to ensure that no incompatible
-                  scrape configs are going to break Grafana Agent after the upgrade."
                 properties:
                   key:
-                    description: The key of the secret to select from.  Must be a
-                      valid secret key.
                     type: string
                   name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                      TODO: Add other useful fields. apiVersion, kind, uid?'
                     type: string
                   optional:
-                    description: Specify whether the Secret or its key must be defined
                     type: boolean
                 required:
                 - key
                 type: object
                 x-kubernetes-map-type: atomic
               clients:
-                description: Clients controls where logs are written to for this instance.
                 items:
-                  description: LogsClientSpec defines the client integration for logs,
-                    indicating which Loki server to send logs to.
                   properties:
                     backoffConfig:
-                      description: Configures how to retry requests to Loki when a
-                        request fails. Defaults to a minPeriod of 500ms, maxPeriod
-                        of 5m, and maxRetries of 10.
                       properties:
                         maxPeriod:
-                          description: Maximum backoff time between retries.
                           type: string
                         maxRetries:
-                          description: Maximum number of retries to perform before
-                            giving up a request.
                           type: integer
                         minPeriod:
-                          description: Initial backoff time between retries. Time
-                            between retries is increased exponentially.
                           type: string
                       type: object
                     basicAuth:
-                      description: BasicAuth for the Loki server.
                       properties:
                         password:
-                          description: The secret in the service monitor namespace
-                            that contains the password for authentication.
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
-                                be a valid secret key.
                               type: string
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must
-                                be defined
                               type: boolean
                           required:
                           - key
                           type: object
                           x-kubernetes-map-type: atomic
                         username:
-                          description: The secret in the service monitor namespace
-                            that contains the username for authentication.
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
-                                be a valid secret key.
                               type: string
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must
-                                be defined
                               type: boolean
                           required:
                           - key
@@ -9672,67 +4606,40 @@ spec:
                           x-kubernetes-map-type: atomic
                       type: object
                     batchSize:
-                      description: Maximum batch size (in bytes) of logs to accumulate
-                        before sending the batch to Loki.
                       type: integer
                     batchWait:
-                      description: Maximum amount of time to wait before sending a
-                        batch, even if that batch isn't full.
                       type: string
                     bearerToken:
-                      description: BearerToken used for remote_write.
                       type: string
                     bearerTokenFile:
-                      description: BearerTokenFile used to read bearer token.
                       type: string
                     externalLabels:
                       additionalProperties:
                         type: string
-                      description: ExternalLabels are labels to add to any time series
-                        when sending data to Loki.
                       type: object
                     oauth2:
-                      description: Oauth2 for URL
                       properties:
                         clientId:
-                          description: The secret or configmap containing the OAuth2
-                            client id
                           properties:
                             configMap:
-                              description: ConfigMap containing data to use for the
-                                targets.
                               properties:
                                 key:
-                                  description: The key to select.
                                   type: string
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its
-                                    key must be defined
                                   type: boolean
                               required:
                               - key
                               type: object
                               x-kubernetes-map-type: atomic
                             secret:
-                              description: Secret containing data to use for the targets.
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must
-                                    be a valid secret key.
                                   type: string
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
-                                    must be defined
                                   type: boolean
                               required:
                               - key
@@ -9740,19 +4647,12 @@ spec:
                               x-kubernetes-map-type: atomic
                           type: object
                         clientSecret:
-                          description: The secret containing the OAuth2 client secret
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
-                                be a valid secret key.
                               type: string
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must
-                                be defined
                               type: boolean
                           required:
                           - key
@@ -9761,15 +4661,12 @@ spec:
                         endpointParams:
                           additionalProperties:
                             type: string
-                          description: Parameters to append to the token URL
                           type: object
                         scopes:
-                          description: OAuth2 scopes used for the token request
                           items:
                             type: string
                           type: array
                         tokenUrl:
-                          description: The URL to fetch the token from
                           minLength: 1
                           type: string
                       required:
@@ -9778,61 +4675,34 @@ spec:
                       - tokenUrl
                       type: object
                     proxyUrl:
-                      description: ProxyURL to proxy requests through. Optional.
                       type: string
                     tenantId:
-                      description: Tenant ID used by default to push logs to Loki.
-                        If omitted assumes remote Loki is running in single-tenant
-                        mode or an authentication layer is used to inject an X-Scope-OrgID
-                        header.
                       type: string
                     timeout:
-                      description: Maximum time to wait for a server to respond to
-                        a request.
                       type: string
                     tlsConfig:
-                      description: TLSConfig to use for the client. Only used when
-                        the protocol of the URL is https.
                       properties:
                         ca:
-                          description: Certificate authority used when verifying server
-                            certificates.
                           properties:
                             configMap:
-                              description: ConfigMap containing data to use for the
-                                targets.
                               properties:
                                 key:
-                                  description: The key to select.
                                   type: string
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its
-                                    key must be defined
                                   type: boolean
                               required:
                               - key
                               type: object
                               x-kubernetes-map-type: atomic
                             secret:
-                              description: Secret containing data to use for the targets.
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must
-                                    be a valid secret key.
                                   type: string
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
-                                    must be defined
                                   type: boolean
                               required:
                               - key
@@ -9840,47 +4710,28 @@ spec:
                               x-kubernetes-map-type: atomic
                           type: object
                         caFile:
-                          description: Path to the CA cert in the Prometheus container
-                            to use for the targets.
                           type: string
                         cert:
-                          description: Client certificate to present when doing client-authentication.
                           properties:
                             configMap:
-                              description: ConfigMap containing data to use for the
-                                targets.
                               properties:
                                 key:
-                                  description: The key to select.
                                   type: string
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its
-                                    key must be defined
                                   type: boolean
                               required:
                               - key
                               type: object
                               x-kubernetes-map-type: atomic
                             secret:
-                              description: Secret containing data to use for the targets.
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must
-                                    be a valid secret key.
                                   type: string
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
-                                    must be defined
                                   type: boolean
                               required:
                               - key
@@ -9888,76 +4739,42 @@ spec:
                               x-kubernetes-map-type: atomic
                           type: object
                         certFile:
-                          description: Path to the client cert file in the Prometheus
-                            container for the targets.
                           type: string
                         insecureSkipVerify:
-                          description: Disable target certificate validation.
                           type: boolean
                         keyFile:
-                          description: Path to the client key file in the Prometheus
-                            container for the targets.
                           type: string
                         keySecret:
-                          description: Secret containing the client key file for the
-                            targets.
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
-                                be a valid secret key.
                               type: string
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must
-                                be defined
                               type: boolean
                           required:
                           - key
                           type: object
                           x-kubernetes-map-type: atomic
                         serverName:
-                          description: Used to verify the hostname for the targets.
                           type: string
                       type: object
                     url:
-                      description: 'URL is the URL where Loki is listening. Must be
-                        a full HTTP URL, including protocol. Required. Example: https://logs-prod-us-central1.grafana.net/loki/api/v1/push.'
                       type: string
                   required:
                   - url
                   type: object
                 type: array
               podLogsNamespaceSelector:
-                description: Set of labels to determine which namespaces should be
-                  watched for PodLogs. If not provided, checks only namespace of the
-                  instance.
                 properties:
                   matchExpressions:
-                    description: matchExpressions is a list of label selector requirements.
-                      The requirements are ANDed.
                     items:
-                      description: A label selector requirement is a selector that
-                        contains values, a key, and an operator that relates the key
-                        and values.
                       properties:
                         key:
-                          description: key is the label key that the selector applies
-                            to.
                           type: string
                         operator:
-                          description: operator represents a key's relationship to
-                            a set of values. Valid operators are In, NotIn, Exists
-                            and DoesNotExist.
                           type: string
                         values:
-                          description: values is an array of string values. If the
-                            operator is In or NotIn, the values array must be non-empty.
-                            If the operator is Exists or DoesNotExist, the values
-                            array must be empty. This array is replaced during a strategic
-                            merge patch.
                           items:
                             type: string
                           type: array
@@ -9969,41 +4786,19 @@ spec:
                   matchLabels:
                     additionalProperties:
                       type: string
-                    description: matchLabels is a map of {key,value} pairs. A single
-                      {key,value} in the matchLabels map is equivalent to an element
-                      of matchExpressions, whose key field is "key", the operator
-                      is "In", and the values array contains only "value". The requirements
-                      are ANDed.
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
               podLogsSelector:
-                description: Determines which PodLogs should be selected for including
-                  in this instance.
                 properties:
                   matchExpressions:
-                    description: matchExpressions is a list of label selector requirements.
-                      The requirements are ANDed.
                     items:
-                      description: A label selector requirement is a selector that
-                        contains values, a key, and an operator that relates the key
-                        and values.
                       properties:
                         key:
-                          description: key is the label key that the selector applies
-                            to.
                           type: string
                         operator:
-                          description: operator represents a key's relationship to
-                            a set of values. Valid operators are In, NotIn, Exists
-                            and DoesNotExist.
                           type: string
                         values:
-                          description: values is an array of string values. If the
-                            operator is In or NotIn, the values array must be non-empty.
-                            If the operator is Exists or DoesNotExist, the values
-                            array must be empty. This array is replaced during a strategic
-                            merge patch.
                           items:
                             type: string
                           type: array
@@ -10015,20 +4810,12 @@ spec:
                   matchLabels:
                     additionalProperties:
                       type: string
-                    description: matchLabels is a map of {key,value} pairs. A single
-                      {key,value} in the matchLabels map is equivalent to an element
-                      of matchExpressions, whose key field is "key", the operator
-                      is "In", and the values array contains only "value". The requirements
-                      are ANDed.
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
               targetConfig:
-                description: Configures how tailed targets are watched.
                 properties:
                   syncPeriod:
-                    description: Period to resync directories being watched and files
-                      being tailed to discover new ones or stop watching removed ones.
                     type: string
                 type: object
             type: object
@@ -10057,89 +4844,41 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: MetricsInstance controls an individual Metrics instance within
-          a Grafana Agent deployment.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           spec:
-            description: Spec holds the specification of the desired behavior for
-              the Metrics instance.
             properties:
               additionalScrapeConfigs:
-                description: 'AdditionalScrapeConfigs lets you specify a key of a
-                  Secret containing additional Grafana Agent Prometheus scrape configurations.
-                  The specified scrape configurations are appended to the configurations
-                  generated by Grafana Agent Operator. Specified job configurations
-                  must have the form specified in the official Prometheus documentation:
-                  https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config.
-                  As scrape configs are appended, you must make sure the configuration
-                  is still valid. Note that it''s possible that this feature will
-                  break future upgrades of Grafana Agent. Review both Grafana Agent
-                  and Prometheus release notes to ensure that no incompatible scrape
-                  configs will break Grafana Agent after the upgrade.'
                 properties:
                   key:
-                    description: The key of the secret to select from.  Must be a
-                      valid secret key.
                     type: string
                   name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                      TODO: Add other useful fields. apiVersion, kind, uid?'
                     type: string
                   optional:
-                    description: Specify whether the Secret or its key must be defined
                     type: boolean
                 required:
                 - key
                 type: object
                 x-kubernetes-map-type: atomic
               maxWALTime:
-                description: MaxWALTime is the maximum amount of time that series
-                  and samples can exist in the WAL before being forcibly deleted.
                 type: string
               minWALTime:
-                description: MinWALTime is the minimum amount of time that series
-                  and samples can exist in the WAL before being considered for deletion.
                 type: string
               podMonitorNamespaceSelector:
-                description: PodMonitorNamespaceSelector are the set of labels to
-                  determine which namespaces to watch for PodMonitor discovery. If
-                  nil, it only checks its own namespace.
                 properties:
                   matchExpressions:
-                    description: matchExpressions is a list of label selector requirements.
-                      The requirements are ANDed.
                     items:
-                      description: A label selector requirement is a selector that
-                        contains values, a key, and an operator that relates the key
-                        and values.
                       properties:
                         key:
-                          description: key is the label key that the selector applies
-                            to.
                           type: string
                         operator:
-                          description: operator represents a key's relationship to
-                            a set of values. Valid operators are In, NotIn, Exists
-                            and DoesNotExist.
                           type: string
                         values:
-                          description: values is an array of string values. If the
-                            operator is In or NotIn, the values array must be non-empty.
-                            If the operator is Exists or DoesNotExist, the values
-                            array must be empty. This array is replaced during a strategic
-                            merge patch.
                           items:
                             type: string
                           type: array
@@ -10151,41 +4890,19 @@ spec:
                   matchLabels:
                     additionalProperties:
                       type: string
-                    description: matchLabels is a map of {key,value} pairs. A single
-                      {key,value} in the matchLabels map is equivalent to an element
-                      of matchExpressions, whose key field is "key", the operator
-                      is "In", and the values array contains only "value". The requirements
-                      are ANDed.
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
               podMonitorSelector:
-                description: PodMonitorSelector determines which PodMonitors to selected
-                  for target discovery. Experimental.
                 properties:
                   matchExpressions:
-                    description: matchExpressions is a list of label selector requirements.
-                      The requirements are ANDed.
                     items:
-                      description: A label selector requirement is a selector that
-                        contains values, a key, and an operator that relates the key
-                        and values.
                       properties:
                         key:
-                          description: key is the label key that the selector applies
-                            to.
                           type: string
                         operator:
-                          description: operator represents a key's relationship to
-                            a set of values. Valid operators are In, NotIn, Exists
-                            and DoesNotExist.
                           type: string
                         values:
-                          description: values is an array of string values. If the
-                            operator is In or NotIn, the values array must be non-empty.
-                            If the operator is Exists or DoesNotExist, the values
-                            array must be empty. This array is replaced during a strategic
-                            merge patch.
                           items:
                             type: string
                           type: array
@@ -10197,42 +4914,19 @@ spec:
                   matchLabels:
                     additionalProperties:
                       type: string
-                    description: matchLabels is a map of {key,value} pairs. A single
-                      {key,value} in the matchLabels map is equivalent to an element
-                      of matchExpressions, whose key field is "key", the operator
-                      is "In", and the values array contains only "value". The requirements
-                      are ANDed.
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
               probeNamespaceSelector:
-                description: ProbeNamespaceSelector is the set of labels that determines
-                  which namespaces to watch for Probe discovery. If nil, it only checks
-                  own namespace.
                 properties:
                   matchExpressions:
-                    description: matchExpressions is a list of label selector requirements.
-                      The requirements are ANDed.
                     items:
-                      description: A label selector requirement is a selector that
-                        contains values, a key, and an operator that relates the key
-                        and values.
                       properties:
                         key:
-                          description: key is the label key that the selector applies
-                            to.
                           type: string
                         operator:
-                          description: operator represents a key's relationship to
-                            a set of values. Valid operators are In, NotIn, Exists
-                            and DoesNotExist.
                           type: string
                         values:
-                          description: values is an array of string values. If the
-                            operator is In or NotIn, the values array must be non-empty.
-                            If the operator is Exists or DoesNotExist, the values
-                            array must be empty. This array is replaced during a strategic
-                            merge patch.
                           items:
                             type: string
                           type: array
@@ -10244,41 +4938,19 @@ spec:
                   matchLabels:
                     additionalProperties:
                       type: string
-                    description: matchLabels is a map of {key,value} pairs. A single
-                      {key,value} in the matchLabels map is equivalent to an element
-                      of matchExpressions, whose key field is "key", the operator
-                      is "In", and the values array contains only "value". The requirements
-                      are ANDed.
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
               probeSelector:
-                description: ProbeSelector determines which Probes to select for target
-                  discovery.
                 properties:
                   matchExpressions:
-                    description: matchExpressions is a list of label selector requirements.
-                      The requirements are ANDed.
                     items:
-                      description: A label selector requirement is a selector that
-                        contains values, a key, and an operator that relates the key
-                        and values.
                       properties:
                         key:
-                          description: key is the label key that the selector applies
-                            to.
                           type: string
                         operator:
-                          description: operator represents a key's relationship to
-                            a set of values. Valid operators are In, NotIn, Exists
-                            and DoesNotExist.
                           type: string
                         values:
-                          description: values is an array of string values. If the
-                            operator is In or NotIn, the values array must be non-empty.
-                            If the operator is Exists or DoesNotExist, the values
-                            array must be empty. This array is replaced during a strategic
-                            merge patch.
                           items:
                             type: string
                           type: array
@@ -10290,62 +4962,35 @@ spec:
                   matchLabels:
                     additionalProperties:
                       type: string
-                    description: matchLabels is a map of {key,value} pairs. A single
-                      {key,value} in the matchLabels map is equivalent to an element
-                      of matchExpressions, whose key field is "key", the operator
-                      is "In", and the values array contains only "value". The requirements
-                      are ANDed.
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
               remoteFlushDeadline:
-                description: RemoteFlushDeadline is the deadline for flushing data
-                  when an instance shuts down.
                 type: string
               remoteWrite:
-                description: RemoteWrite controls remote_write settings for this instance.
                 items:
-                  description: RemoteWriteSpec defines the remote_write configuration
-                    for Prometheus.
                   properties:
                     basicAuth:
-                      description: BasicAuth for the URL.
                       properties:
                         password:
-                          description: The secret in the service monitor namespace
-                            that contains the password for authentication.
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
-                                be a valid secret key.
                               type: string
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must
-                                be defined
                               type: boolean
                           required:
                           - key
                           type: object
                           x-kubernetes-map-type: atomic
                         username:
-                          description: The secret in the service monitor namespace
-                            that contains the username for authentication.
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
-                                be a valid secret key.
                               type: string
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must
-                                be defined
                               type: boolean
                           required:
                           - key
@@ -10353,78 +4998,45 @@ spec:
                           x-kubernetes-map-type: atomic
                       type: object
                     bearerToken:
-                      description: BearerToken used for remote_write.
                       type: string
                     bearerTokenFile:
-                      description: BearerTokenFile used to read bearer token.
                       type: string
                     headers:
                       additionalProperties:
                         type: string
-                      description: Headers is a set of custom HTTP headers to be sent
-                        along with each remote_write request. Be aware that any headers
-                        set by Grafana Agent itself can't be overwritten.
                       type: object
                     metadataConfig:
-                      description: MetadataConfig configures the sending of series
-                        metadata to remote storage.
                       properties:
                         send:
-                          description: Send enables metric metadata to be sent to
-                            remote storage.
                           type: boolean
                         sendInterval:
-                          description: SendInterval controls how frequently metric
-                            metadata is sent to remote storage.
                           type: string
                       type: object
                     name:
-                      description: Name of the remote_write queue. Must be unique
-                        if specified. The name is used in metrics and logging in order
-                        to differentiate queues.
                       type: string
                     oauth2:
-                      description: Oauth2 for URL
                       properties:
                         clientId:
-                          description: The secret or configmap containing the OAuth2
-                            client id
                           properties:
                             configMap:
-                              description: ConfigMap containing data to use for the
-                                targets.
                               properties:
                                 key:
-                                  description: The key to select.
                                   type: string
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its
-                                    key must be defined
                                   type: boolean
                               required:
                               - key
                               type: object
                               x-kubernetes-map-type: atomic
                             secret:
-                              description: Secret containing data to use for the targets.
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must
-                                    be a valid secret key.
                                   type: string
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
-                                    must be defined
                                   type: boolean
                               required:
                               - key
@@ -10432,19 +5044,12 @@ spec:
                               x-kubernetes-map-type: atomic
                           type: object
                         clientSecret:
-                          description: The secret containing the OAuth2 client secret
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
-                                be a valid secret key.
                               type: string
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must
-                                be defined
                               type: boolean
                           required:
                           - key
@@ -10453,15 +5058,12 @@ spec:
                         endpointParams:
                           additionalProperties:
                             type: string
-                          description: Parameters to append to the token URL
                           type: object
                         scopes:
-                          description: OAuth2 scopes used for the token request
                           items:
                             type: string
                           type: array
                         tokenUrl:
-                          description: The URL to fetch the token from
                           minLength: 1
                           type: string
                       required:
@@ -10470,106 +5072,57 @@ spec:
                       - tokenUrl
                       type: object
                     proxyUrl:
-                      description: ProxyURL to proxy requests through. Optional.
                       type: string
                     queueConfig:
-                      description: QueueConfig allows tuning of the remote_write queue
-                        parameters.
                       properties:
                         batchSendDeadline:
-                          description: BatchSendDeadline is the maximum time a sample
-                            will wait in the buffer.
                           type: string
                         capacity:
-                          description: Capacity is the number of samples to buffer
-                            per shard before samples start being dropped.
                           type: integer
                         maxBackoff:
-                          description: MaxBackoff is the maximum retry delay.
                           type: string
                         maxRetries:
-                          description: MaxRetries is the maximum number of times to
-                            retry a batch on recoverable errors.
                           type: integer
                         maxSamplesPerSend:
-                          description: MaxSamplesPerSend is the maximum number of
-                            samples per send.
                           type: integer
                         maxShards:
-                          description: MaxShards is the maximum number of shards,
-                            i.e., the amount of concurrency.
                           type: integer
                         minBackoff:
-                          description: MinBackoff is the initial retry delay. MinBackoff
-                            is doubled for every retry.
                           type: string
                         minShards:
-                          description: MinShards is the minimum number of shards,
-                            i.e., the amount of concurrency.
                           type: integer
                         retryOnRateLimit:
-                          description: RetryOnRateLimit retries requests when encountering
-                            rate limits.
                           type: boolean
                       type: object
                     remoteTimeout:
-                      description: RemoteTimeout is the timeout for requests to the
-                        remote_write endpoint.
                       type: string
                     sigv4:
-                      description: SigV4 configures SigV4-based authentication to
-                        the remote_write endpoint. SigV4-based authentication is used
-                        if SigV4 is defined, even with an empty object.
                       properties:
                         accessKey:
-                          description: AccessKey holds the secret of the AWS API access
-                            key to use for signing. If not provided, the environment
-                            variable AWS_ACCESS_KEY_ID is used.
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
-                                be a valid secret key.
                               type: string
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must
-                                be defined
                               type: boolean
                           required:
                           - key
                           type: object
                           x-kubernetes-map-type: atomic
                         profile:
-                          description: Profile is the named AWS profile to use for
-                            authentication.
                           type: string
                         region:
-                          description: Region of the AWS endpoint. If blank, the region
-                            from the default credentials chain is used.
                           type: string
                         roleARN:
-                          description: RoleARN is the AWS Role ARN to use for authentication,
-                            as an alternative for using the AWS API keys.
                           type: string
                         secretKey:
-                          description: SecretKey of the AWS API to use for signing.
-                            If blank, the environment variable AWS_SECRET_ACCESS_KEY
-                            is used.
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
-                                be a valid secret key.
                               type: string
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must
-                                be defined
                               type: boolean
                           required:
                           - key
@@ -10577,47 +5130,28 @@ spec:
                           x-kubernetes-map-type: atomic
                       type: object
                     tlsConfig:
-                      description: TLSConfig to use for remote_write.
                       properties:
                         ca:
-                          description: Certificate authority used when verifying server
-                            certificates.
                           properties:
                             configMap:
-                              description: ConfigMap containing data to use for the
-                                targets.
                               properties:
                                 key:
-                                  description: The key to select.
                                   type: string
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its
-                                    key must be defined
                                   type: boolean
                               required:
                               - key
                               type: object
                               x-kubernetes-map-type: atomic
                             secret:
-                              description: Secret containing data to use for the targets.
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must
-                                    be a valid secret key.
                                   type: string
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
-                                    must be defined
                                   type: boolean
                               required:
                               - key
@@ -10625,47 +5159,28 @@ spec:
                               x-kubernetes-map-type: atomic
                           type: object
                         caFile:
-                          description: Path to the CA cert in the Prometheus container
-                            to use for the targets.
                           type: string
                         cert:
-                          description: Client certificate to present when doing client-authentication.
                           properties:
                             configMap:
-                              description: ConfigMap containing data to use for the
-                                targets.
                               properties:
                                 key:
-                                  description: The key to select.
                                   type: string
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its
-                                    key must be defined
                                   type: boolean
                               required:
                               - key
                               type: object
                               x-kubernetes-map-type: atomic
                             secret:
-                              description: Secret containing data to use for the targets.
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must
-                                    be a valid secret key.
                                   type: string
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
-                                    must be defined
                                   type: boolean
                               required:
                               - key
@@ -10673,57 +5188,33 @@ spec:
                               x-kubernetes-map-type: atomic
                           type: object
                         certFile:
-                          description: Path to the client cert file in the Prometheus
-                            container for the targets.
                           type: string
                         insecureSkipVerify:
-                          description: Disable target certificate validation.
                           type: boolean
                         keyFile:
-                          description: Path to the client key file in the Prometheus
-                            container for the targets.
                           type: string
                         keySecret:
-                          description: Secret containing the client key file for the
-                            targets.
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
-                                be a valid secret key.
                               type: string
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must
-                                be defined
                               type: boolean
                           required:
                           - key
                           type: object
                           x-kubernetes-map-type: atomic
                         serverName:
-                          description: Used to verify the hostname for the targets.
                           type: string
                       type: object
                     url:
-                      description: URL of the endpoint to send samples to.
                       type: string
                     writeRelabelConfigs:
-                      description: WriteRelabelConfigs holds relabel_configs to relabel
-                        samples before they are sent to the remote_write endpoint.
                       items:
-                        description: 'RelabelConfig allows dynamic rewriting of the
-                          label set, being applied to samples before ingestion. It
-                          defines `<metric_relabel_configs>`-section of Prometheus
-                          configuration. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
                         properties:
                           action:
                             default: replace
-                            description: Action to perform based on regex matching.
-                              Default is 'replace'. uppercase and lowercase actions
-                              require Prometheus >= 2.36.
                             enum:
                             - replace
                             - Replace
@@ -10749,39 +5240,20 @@ spec:
                             - DropEqual
                             type: string
                           modulus:
-                            description: Modulus to take of the hash of the source
-                              label values.
                             format: int64
                             type: integer
                           regex:
-                            description: Regular expression against which the extracted
-                              value is matched. Default is '(.*)'
                             type: string
                           replacement:
-                            description: Replacement value against which a regex replace
-                              is performed if the regular expression matches. Regex
-                              capture groups are available. Default is '$1'
                             type: string
                           separator:
-                            description: Separator placed between concatenated source
-                              label values. default is ';'.
                             type: string
                           sourceLabels:
-                            description: The source labels select values from existing
-                              labels. Their content is concatenated using the configured
-                              separator and matched against the configured regular
-                              expression for the replace, keep, and drop actions.
                             items:
-                              description: LabelName is a valid Prometheus label name
-                                which may only contain ASCII letters, numbers, as
-                                well as underscores.
                               pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
                               type: string
                             type: array
                           targetLabel:
-                            description: Label to which the resulting value is written
-                              in a replace action. It is mandatory for replace actions.
-                              Regex capture groups are available.
                             type: string
                         type: object
                       type: array
@@ -10790,33 +5262,15 @@ spec:
                   type: object
                 type: array
               serviceMonitorNamespaceSelector:
-                description: ServiceMonitorNamespaceSelector is the set of labels
-                  that determine which namespaces to watch for ServiceMonitor discovery.
-                  If nil, it only checks its own namespace.
                 properties:
                   matchExpressions:
-                    description: matchExpressions is a list of label selector requirements.
-                      The requirements are ANDed.
                     items:
-                      description: A label selector requirement is a selector that
-                        contains values, a key, and an operator that relates the key
-                        and values.
                       properties:
                         key:
-                          description: key is the label key that the selector applies
-                            to.
                           type: string
                         operator:
-                          description: operator represents a key's relationship to
-                            a set of values. Valid operators are In, NotIn, Exists
-                            and DoesNotExist.
                           type: string
                         values:
-                          description: values is an array of string values. If the
-                            operator is In or NotIn, the values array must be non-empty.
-                            If the operator is Exists or DoesNotExist, the values
-                            array must be empty. This array is replaced during a strategic
-                            merge patch.
                           items:
                             type: string
                           type: array
@@ -10828,41 +5282,19 @@ spec:
                   matchLabels:
                     additionalProperties:
                       type: string
-                    description: matchLabels is a map of {key,value} pairs. A single
-                      {key,value} in the matchLabels map is equivalent to an element
-                      of matchExpressions, whose key field is "key", the operator
-                      is "In", and the values array contains only "value". The requirements
-                      are ANDed.
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
               serviceMonitorSelector:
-                description: ServiceMonitorSelector determines which ServiceMonitors
-                  to select for target discovery.
                 properties:
                   matchExpressions:
-                    description: matchExpressions is a list of label selector requirements.
-                      The requirements are ANDed.
                     items:
-                      description: A label selector requirement is a selector that
-                        contains values, a key, and an operator that relates the key
-                        and values.
                       properties:
                         key:
-                          description: key is the label key that the selector applies
-                            to.
                           type: string
                         operator:
-                          description: operator represents a key's relationship to
-                            a set of values. Valid operators are In, NotIn, Exists
-                            and DoesNotExist.
                           type: string
                         values:
-                          description: values is an array of string values. If the
-                            operator is In or NotIn, the values array must be non-empty.
-                            If the operator is Exists or DoesNotExist, the values
-                            array must be empty. This array is replaced during a strategic
-                            merge patch.
                           items:
                             type: string
                           type: array
@@ -10874,23 +5306,12 @@ spec:
                   matchLabels:
                     additionalProperties:
                       type: string
-                    description: matchLabels is a map of {key,value} pairs. A single
-                      {key,value} in the matchLabels map is equivalent to an element
-                      of matchExpressions, whose key field is "key", the operator
-                      is "In", and the values array contains only "value". The requirements
-                      are ANDed.
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
               walTruncateFrequency:
-                description: WALTruncateFrequency specifies how frequently to run
-                  the WAL truncation process. Higher values cause the WAL to increase
-                  and for old series to stay in the WAL longer, but reduces the chance
-                  of data loss when remote_write fails for longer than the given frequency.
                 type: string
               writeStaleOnShutdown:
-                description: WriteStaleOnShutdown writes staleness markers on shutdown
-                  for all series.
                 type: boolean
             type: object
         type: object
@@ -10918,325 +5339,146 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: PodLogs defines how to collect logs for a pod.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           spec:
-            description: Spec holds the specification of the desired behavior for
-              the PodLogs.
             properties:
               jobLabel:
-                description: The label to use to retrieve the job name from.
                 type: string
               namespaceSelector:
-                description: Selector to select which namespaces the Pod objects are
-                  discovered from.
                 properties:
                   any:
-                    description: Boolean describing whether all namespaces are selected
-                      in contrast to a list restricting them.
                     type: boolean
                   matchNames:
-                    description: List of namespace names to select from.
                     items:
                       type: string
                     type: array
                 type: object
               pipelineStages:
-                description: Pipeline stages for this pod. Pipeline stages support
-                  transforming and filtering log lines.
                 items:
-                  description: "PipelineStageSpec defines an individual pipeline stage.
-                    Each stage type is mutually exclusive and no more than one may
-                    be set per stage. \n More information on pipelines can be found
-                    in the Promtail documentation: https://grafana.com/docs/loki/latest/clients/promtail/pipelines/"
                   properties:
                     cri:
-                      description: 'CRI is a parsing stage that reads log lines using
-                        the standard CRI logging format. Supply cri: {} to enable.'
                       type: object
                     docker:
-                      description: 'Docker is a parsing stage that reads log lines
-                        using the standard Docker logging format. Supply docker: {}
-                        to enable.'
                       type: object
                     drop:
-                      description: Drop is a filtering stage that lets you drop certain
-                        logs.
                       properties:
                         dropCounterReason:
-                          description: Every time a log line is dropped, the metric
-                            logentry_dropped_lines_total is incremented. A "reason"
-                            label is added, and can be customized by providing a custom
-                            value here. Defaults to "drop_stage".
                           type: string
                         expression:
-                          description: "RE2 regular expression. \n If source is provided,
-                            the regex attempts to match the source. \n If no source
-                            is provided, then the regex attempts to attach the log
-                            line. \n If the provided regex matches the log line or
-                            a provided source, the line is dropped."
                           type: string
                         longerThan:
-                          description: LongerThan will drop a log line if it its content
-                            is longer than this value (in bytes). Can be expressed
-                            as an integer (8192) or a number with a suffix (8kb).
                           type: string
                         olderThan:
-                          description: OlderThan will be parsed as a Go duration.
-                            If the log line's timestamp is older than the current
-                            time minus the provided duration, it will be dropped.
                           type: string
                         source:
-                          description: Name from the extract data to parse. If empty,
-                            uses the log message.
                           type: string
                         value:
-                          description: "Value can only be specified when source is
-                            specified. If the value provided is an exact match for
-                            the given source then the line will be dropped. \n Mutually
-                            exclusive with expression."
                           type: string
                       type: object
                     json:
-                      description: "JSON is a parsing stage that reads the log line
-                        as JSON and accepts JMESPath expressions to extract data.
-                        \n Information on JMESPath: http://jmespath.org/"
                       properties:
                         expressions:
                           additionalProperties:
                             type: string
-                          description: "Set of the key/value pairs of JMESPath expressions.
-                            The key will be the key in the extracted data while the
-                            expression will be the value, evaluated as a JMESPath
-                            from the source data. \n Literal JMESPath expressions
-                            can be used by wrapping a key in double quotes, which
-                            then must be wrapped again in single quotes in YAML so
-                            they get passed to the JMESPath parser."
                           type: object
                         source:
-                          description: Name from the extracted data to parse as JSON.
-                            If empty, uses entire log message.
                           type: string
                       type: object
                     labelAllow:
-                      description: LabelAllow is an action stage that only allows
-                        the provided labels to be included in the label set that is
-                        sent to Loki with the log entry.
                       items:
                         type: string
                       type: array
                     labelDrop:
-                      description: LabelDrop is an action stage that drops labels
-                        from the label set that is sent to Loki with the log entry.
                       items:
                         type: string
                       type: array
                     labels:
                       additionalProperties:
                         type: string
-                      description: "Labels is an action stage that takes data from
-                        the extracted map and modifies the label set that is sent
-                        to Loki with the log entry. \n The key is REQUIRED and represents
-                        the name for the label that will be created. Value is optional
-                        and will be the name from extracted data to use for the value
-                        of the label. If the value is not provided, it defaults to
-                        match the key."
                       type: object
                     limit:
-                      description: Limit is a rate-limiting stage that throttles logs
-                        based on several options.
                       properties:
                         burst:
-                          description: The cap in the quantity of burst lines that
-                            Promtail will push to Loki.
                           type: integer
                         drop:
-                          description: "When drop is true, log lines that exceed the
-                            current rate limit are discarded. When drop is false,
-                            log lines that exceed the current rate limit wait to enter
-                            the back pressure mode. \n Defaults to false."
                           type: boolean
                         rate:
-                          description: The rate limit in lines per second that Promtail
-                            will push to Loki.
                           type: integer
                       type: object
                     match:
-                      description: Match is a filtering stage that conditionally applies
-                        a set of stages or drop entries when a log entry matches a
-                        configurable LogQL stream selector and filter expressions.
                       properties:
                         action:
-                          description: Determines what action is taken when the selector
-                            matches the log line. Can be keep or drop. Defaults to
-                            keep. When set to drop, entries are dropped and no later
-                            metrics are recorded. Stages must be empty when dropping
-                            metrics.
                           type: string
                         dropCounterReason:
-                          description: Every time a log line is dropped, the metric
-                            logentry_dropped_lines_total is incremented. A "reason"
-                            label is added, and can be customized by providing a custom
-                            value here. Defaults to "match_stage."
                           type: string
                         pipelineName:
-                          description: Names the pipeline. When defined, creates an
-                            additional label in the pipeline_duration_seconds histogram,
-                            where the value is concatenated with job_name using an
-                            underscore.
                           type: string
                         selector:
-                          description: LogQL stream selector and filter expressions.
-                            Required.
                           type: string
                         stages:
-                          description: "Nested set of pipeline stages to execute when
-                            action is keep and the log line matches selector. \n An
-                            example value for stages may be: \n stages: | - json:
-                            {} - labelAllow: [foo, bar] \n Note that stages is a string
-                            because SIG API Machinery does not support recursive types,
-                            and so it cannot be validated for correctness. Be careful
-                            not to mistype anything."
                           type: string
                       required:
                       - selector
                       type: object
                     metrics:
                       additionalProperties:
-                        description: MetricsStageSpec is an action stage that allows
-                          for defining and updating metrics based on data from the
-                          extracted map. Created metrics are not pushed to Loki or
-                          Prometheus and are instead exposed via the /metrics endpoint
-                          of the Grafana Agent pod. The Grafana Agent Operator should
-                          be configured with a MetricsInstance that discovers the
-                          logging DaemonSet to collect metrics created by this stage.
                         properties:
                           action:
-                            description: "The action to take against the metric. Required.
-                              \n Must be either \"inc\" or \"add\" for type: counter
-                              or type: histogram. When type: gauge, must be one of
-                              \"set\", \"inc\", \"dec\", \"add\", or \"sub\". \n \"add\",
-                              \"set\", or \"sub\" requires the extracted value to
-                              be convertible to a positive float."
                             type: string
                           buckets:
-                            description: 'Buckets to create. Bucket values must be
-                              convertible to float64s. Extremely large or small numbers
-                              are subject to some loss of precision. Only valid for
-                              type: histogram.'
                             items:
                               type: string
                             type: array
                           countEntryBytes:
-                            description: "If true all log line bytes are counted.
-                              Can only be set with matchAll: true and action: add.
-                              \n Only valid for type: counter."
                             type: boolean
                           description:
-                            description: Sets the description for the created metric.
                             type: string
                           matchAll:
-                            description: "If true, all log lines are counted without
-                              attempting to match the source to the extracted map.
-                              Mutually exclusive with value. \n Only valid for type:
-                              counter."
                             type: boolean
                           maxIdleDuration:
-                            description: "Label values on metrics are dynamic which
-                              can cause exported metrics to go stale. To prevent unbounded
-                              cardinality, any metrics not updated within MaxIdleDuration
-                              are removed. \n Must be greater or equal to 1s. Defaults
-                              to 5m."
                             type: string
                           prefix:
-                            description: Sets the custom prefix name for the metric.
-                              Defaults to "promtail_custom_".
                             type: string
                           source:
-                            description: Key from the extracted data map to use for
-                              the metric. Defaults to the metrics name if not present.
                             type: string
                           type:
-                            description: The metric type to create. Must be one of
-                              counter, gauge, histogram. Required.
                             type: string
                           value:
-                            description: Filters down source data and only changes
-                              the metric if the targeted value matches the provided
-                              string exactly. If not present, all data matches.
                             type: string
                         required:
                         - action
                         - type
                         type: object
-                      description: Metrics is an action stage that supports defining
-                        and updating metrics based on data from the extracted map.
-                        Created metrics are not pushed to Loki or Prometheus and are
-                        instead exposed via the /metrics endpoint of the Grafana Agent
-                        pod. The Grafana Agent Operator should be configured with
-                        a MetricsInstance that discovers the logging DaemonSet to
-                        collect metrics created by this stage.
                       type: object
                     multiline:
-                      description: Multiline stage merges multiple lines into a multiline
-                        block before passing it on to the next stage in the pipeline.
                       properties:
                         firstLine:
-                          description: RE2 regular expression. Creates a new multiline
-                            block when matched. Required.
                           type: string
                         maxLines:
-                          description: Maximum number of lines a block can have. A
-                            new block is started if the number of lines surpasses
-                            this value. Defaults to 128.
                           type: integer
                         maxWaitTime:
-                          description: Maximum time to wait before passing on the
-                            multiline block to the next stage if no new lines are
-                            received. Defaults to 3s.
                           type: string
                       required:
                       - firstLine
                       type: object
                     output:
-                      description: Output stage is an action stage that takes data
-                        from the extracted map and changes the log line that will
-                        be sent to Loki.
                       properties:
                         source:
-                          description: Name from extract data to use for the log entry.
-                            Required.
                           type: string
                       required:
                       - source
                       type: object
                     pack:
-                      description: Pack is a transform stage that lets you embed extracted
-                        values and labels into the log line by packing the log line
-                        and labels inside of a JSON object.
                       properties:
                         ingestTimestamp:
-                          description: If the resulting log line should use any existing
-                            timestamp or use time.Now() when the line was created.
-                            Set to true when combining several log streams from different
-                            containers to avoid out of order errors.
                           type: boolean
                         labels:
-                          description: Name from extracted data or line labels. Required.
-                            Labels provided here are automatically removed from output
-                            labels.
                           items:
                             type: string
                           type: array
@@ -11244,107 +5486,57 @@ spec:
                       - labels
                       type: object
                     regex:
-                      description: Regex is a parsing stage that parses a log line
-                        using a regular expression.  Named capture groups in the regex
-                        allows for adding data into the extracted map.
                       properties:
                         expression:
-                          description: RE2 regular expression. Each capture group
-                            MUST be named. Required.
                           type: string
                         source:
-                          description: Name from extracted data to parse. If empty,
-                            defaults to using the log message.
                           type: string
                       required:
                       - expression
                       type: object
                     replace:
-                      description: Replace is a parsing stage that parses a log line
-                        using a regular expression and replaces the log line. Named
-                        capture groups in the regex allows for adding data into the
-                        extracted map.
                       properties:
                         expression:
-                          description: RE2 regular expression. Each capture group
-                            MUST be named. Required.
                           type: string
                         replace:
-                          description: Value to replace the captured group with.
                           type: string
                         source:
-                          description: Name from extracted data to parse. If empty,
-                            defaults to using the log message.
                           type: string
                       required:
                       - expression
                       type: object
                     template:
-                      description: Template is a transform stage that manipulates
-                        the values in the extracted map using Go's template syntax.
                       properties:
                         source:
-                          description: Name from extracted data to parse. Required.
-                            If empty, defaults to using the log message.
                           type: string
                         template:
-                          description: Go template string to use. Required. In addition
-                            to normal template functions, ToLower, ToUpper, Replace,
-                            Trim, TrimLeft, TrimRight, TrimPrefix, and TrimSpace are
-                            also available.
                           type: string
                       required:
                       - source
                       - template
                       type: object
                     tenant:
-                      description: Tenant is an action stage that sets the tenant
-                        ID for the log entry picking it from a field in the extracted
-                        data map. If the field is missing, the default LogsClientSpec.tenantId
-                        will be used.
                       properties:
                         label:
-                          description: Name from labels whose value should be set
-                            as tenant ID. Mutually exclusive with source and value.
                           type: string
                         source:
-                          description: Name from extracted data to use as the tenant
-                            ID. Mutually exclusive with label and value.
                           type: string
                         value:
-                          description: Value to use for the template ID. Useful when
-                            this stage is used within a conditional pipeline such
-                            as match. Mutually exclusive with label and source.
                           type: string
                       type: object
                     timestamp:
-                      description: Timestamp is an action stage that can change the
-                        timestamp of a log line before it is sent to Loki. If not
-                        present, the timestamp of a log line defaults to the time
-                        when the log line was read.
                       properties:
                         actionOnFailure:
-                          description: Action to take when the timestamp can't be
-                            extracted or parsed. Can be skip or fudge. Defaults to
-                            fudge.
                           type: string
                         fallbackFormats:
-                          description: Fallback formats to try if format fails.
                           items:
                             type: string
                           type: array
                         format:
-                          description: 'Determines format of the time string. Required.
-                            Can be one of: ANSIC, UnixDate, RubyDate, RFC822, RFC822Z,
-                            RFC850, RFC1123, RFC1123Z, RFC3339, RFC3339Nano, Unix,
-                            UnixMs, UnixUs, UnixNs.'
                           type: string
                         location:
-                          description: IANA Timezone Database string.
                           type: string
                         source:
-                          description: Name from extracted data to use as the timestamp.
-                            Required.
                           type: string
                       required:
                       - format
@@ -11353,26 +5545,14 @@ spec:
                   type: object
                 type: array
               podTargetLabels:
-                description: PodTargetLabels transfers labels on the Kubernetes Pod
-                  onto the target.
                 items:
                   type: string
                 type: array
               relabelings:
-                description: "RelabelConfigs to apply to logs before delivering. Grafana
-                  Agent Operator automatically adds relabelings for a few standard
-                  Kubernetes fields and replaces original scrape job name with __tmp_logs_job_name.
-                  \n More info: https://grafana.com/docs/loki/latest/clients/promtail/configuration/#relabel_configs"
                 items:
-                  description: 'RelabelConfig allows dynamic rewriting of the label
-                    set, being applied to samples before ingestion. It defines `<metric_relabel_configs>`-section
-                    of Prometheus configuration. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
                   properties:
                     action:
                       default: replace
-                      description: Action to perform based on regex matching. Default
-                        is 'replace'. uppercase and lowercase actions require Prometheus
-                        >= 2.36.
                       enum:
                       - replace
                       - Replace
@@ -11398,67 +5578,33 @@ spec:
                       - DropEqual
                       type: string
                     modulus:
-                      description: Modulus to take of the hash of the source label
-                        values.
                       format: int64
                       type: integer
                     regex:
-                      description: Regular expression against which the extracted
-                        value is matched. Default is '(.*)'
                       type: string
                     replacement:
-                      description: Replacement value against which a regex replace
-                        is performed if the regular expression matches. Regex capture
-                        groups are available. Default is '$1'
                       type: string
                     separator:
-                      description: Separator placed between concatenated source label
-                        values. default is ';'.
                       type: string
                     sourceLabels:
-                      description: The source labels select values from existing labels.
-                        Their content is concatenated using the configured separator
-                        and matched against the configured regular expression for
-                        the replace, keep, and drop actions.
                       items:
-                        description: LabelName is a valid Prometheus label name which
-                          may only contain ASCII letters, numbers, as well as underscores.
                         pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
                         type: string
                       type: array
                     targetLabel:
-                      description: Label to which the resulting value is written in
-                        a replace action. It is mandatory for replace actions. Regex
-                        capture groups are available.
                       type: string
                   type: object
                 type: array
               selector:
-                description: Selector to select Pod objects. Required.
                 properties:
                   matchExpressions:
-                    description: matchExpressions is a list of label selector requirements.
-                      The requirements are ANDed.
                     items:
-                      description: A label selector requirement is a selector that
-                        contains values, a key, and an operator that relates the key
-                        and values.
                       properties:
                         key:
-                          description: key is the label key that the selector applies
-                            to.
                           type: string
                         operator:
-                          description: operator represents a key's relationship to
-                            a set of values. Valid operators are In, NotIn, Exists
-                            and DoesNotExist.
                           type: string
                         values:
-                          description: values is an array of string values. If the
-                            operator is In or NotIn, the values array must be non-empty.
-                            If the operator is Exists or DoesNotExist, the values
-                            array must be empty. This array is replaced during a strategic
-                            merge patch.
                           items:
                             type: string
                           type: array
@@ -11470,11 +5616,6 @@ spec:
                   matchLabels:
                     additionalProperties:
                       type: string
-                    description: matchLabels is a map of {key,value} pairs. A single
-                      {key,value} in the matchLabels map is equivalent to an element
-                      of matchExpressions, whose key field is "key", the operator
-                      is "In", and the values array contains only "value". The requirements
-                      are ANDed.
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
@@ -11508,140 +5649,81 @@ spec:
   - name: v1
     schema:
       openAPIV3Schema:
-        description: PodMonitor defines monitoring for a set of pods.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           spec:
-            description: Specification of desired Pod selection for target discovery
-              by Prometheus.
             properties:
               attachMetadata:
-                description: Attaches node metadata to discovered targets. Requires
-                  Prometheus v2.35.0 and above.
                 properties:
                   node:
-                    description: When set to true, Prometheus must have permissions
-                      to get Nodes.
                     type: boolean
                 type: object
               jobLabel:
-                description: The label to use to retrieve the job name from.
                 type: string
               labelLimit:
-                description: Per-scrape limit on number of labels that will be accepted
-                  for a sample. Only valid in Prometheus versions 2.27.0 and newer.
                 format: int64
                 type: integer
               labelNameLengthLimit:
-                description: Per-scrape limit on length of labels name that will be
-                  accepted for a sample. Only valid in Prometheus versions 2.27.0
-                  and newer.
                 format: int64
                 type: integer
               labelValueLengthLimit:
-                description: Per-scrape limit on length of labels value that will
-                  be accepted for a sample. Only valid in Prometheus versions 2.27.0
-                  and newer.
                 format: int64
                 type: integer
               namespaceSelector:
-                description: Selector to select which namespaces the Endpoints objects
-                  are discovered from.
                 properties:
                   any:
-                    description: Boolean describing whether all namespaces are selected
-                      in contrast to a list restricting them.
                     type: boolean
                   matchNames:
-                    description: List of namespace names to select from.
                     items:
                       type: string
                     type: array
                 type: object
               podMetricsEndpoints:
-                description: A list of endpoints allowed as part of this PodMonitor.
                 items:
-                  description: PodMetricsEndpoint defines a scrapeable endpoint of
-                    a Kubernetes Pod serving Prometheus metrics.
                   properties:
                     authorization:
-                      description: Authorization section for this endpoint
                       properties:
                         credentials:
-                          description: The secret's key that contains the credentials
-                            of the request
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
-                                be a valid secret key.
                               type: string
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must
-                                be defined
                               type: boolean
                           required:
                           - key
                           type: object
                           x-kubernetes-map-type: atomic
                         type:
-                          description: Set the authentication type. Defaults to Bearer,
-                            Basic will cause an error
                           type: string
                       type: object
                     basicAuth:
-                      description: 'BasicAuth allow an endpoint to authenticate over
-                        basic authentication. More info: https://prometheus.io/docs/operating/configuration/#endpoint'
                       properties:
                         password:
-                          description: The secret in the service monitor namespace
-                            that contains the password for authentication.
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
-                                be a valid secret key.
                               type: string
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must
-                                be defined
                               type: boolean
                           required:
                           - key
                           type: object
                           x-kubernetes-map-type: atomic
                         username:
-                          description: The secret in the service monitor namespace
-                            that contains the username for authentication.
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
-                                be a valid secret key.
                               type: string
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must
-                                be defined
                               type: boolean
                           required:
                           - key
@@ -11649,64 +5731,35 @@ spec:
                           x-kubernetes-map-type: atomic
                       type: object
                     bearerTokenSecret:
-                      description: Secret to mount to read bearer token for scraping
-                        targets. The secret needs to be in the same namespace as the
-                        pod monitor and accessible by the Prometheus Operator.
                       properties:
                         key:
-                          description: The key of the secret to select from.  Must
-                            be a valid secret key.
                           type: string
                         name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?'
                           type: string
                         optional:
-                          description: Specify whether the Secret or its key must
-                            be defined
                           type: boolean
                       required:
                       - key
                       type: object
                       x-kubernetes-map-type: atomic
                     enableHttp2:
-                      description: Whether to enable HTTP2.
                       type: boolean
                     filterRunning:
-                      description: 'Drop pods that are not running. (Failed, Succeeded).
-                        Enabled by default. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase'
                       type: boolean
                     followRedirects:
-                      description: FollowRedirects configures whether scrape requests
-                        follow HTTP 3xx redirects.
                       type: boolean
                     honorLabels:
-                      description: HonorLabels chooses the metric's labels on collisions
-                        with target labels.
                       type: boolean
                     honorTimestamps:
-                      description: HonorTimestamps controls whether Prometheus respects
-                        the timestamps present in scraped data.
                       type: boolean
                     interval:
-                      description: Interval at which metrics should be scraped If
-                        not specified Prometheus' global scrape interval is used.
                       pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                       type: string
                     metricRelabelings:
-                      description: MetricRelabelConfigs to apply to samples before
-                        ingestion.
                       items:
-                        description: 'RelabelConfig allows dynamic rewriting of the
-                          label set, being applied to samples before ingestion. It
-                          defines `<metric_relabel_configs>`-section of Prometheus
-                          configuration. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
                         properties:
                           action:
                             default: replace
-                            description: Action to perform based on regex matching.
-                              Default is 'replace'. uppercase and lowercase actions
-                              require Prometheus >= 2.36.
                             enum:
                             - replace
                             - Replace
@@ -11732,85 +5785,46 @@ spec:
                             - DropEqual
                             type: string
                           modulus:
-                            description: Modulus to take of the hash of the source
-                              label values.
                             format: int64
                             type: integer
                           regex:
-                            description: Regular expression against which the extracted
-                              value is matched. Default is '(.*)'
                             type: string
                           replacement:
-                            description: Replacement value against which a regex replace
-                              is performed if the regular expression matches. Regex
-                              capture groups are available. Default is '$1'
                             type: string
                           separator:
-                            description: Separator placed between concatenated source
-                              label values. default is ';'.
                             type: string
                           sourceLabels:
-                            description: The source labels select values from existing
-                              labels. Their content is concatenated using the configured
-                              separator and matched against the configured regular
-                              expression for the replace, keep, and drop actions.
                             items:
-                              description: LabelName is a valid Prometheus label name
-                                which may only contain ASCII letters, numbers, as
-                                well as underscores.
                               pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
                               type: string
                             type: array
                           targetLabel:
-                            description: Label to which the resulting value is written
-                              in a replace action. It is mandatory for replace actions.
-                              Regex capture groups are available.
                             type: string
                         type: object
                       type: array
                     oauth2:
-                      description: OAuth2 for the URL. Only valid in Prometheus versions
-                        2.27.0 and newer.
                       properties:
                         clientId:
-                          description: The secret or configmap containing the OAuth2
-                            client id
                           properties:
                             configMap:
-                              description: ConfigMap containing data to use for the
-                                targets.
                               properties:
                                 key:
-                                  description: The key to select.
                                   type: string
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its
-                                    key must be defined
                                   type: boolean
                               required:
                               - key
                               type: object
                               x-kubernetes-map-type: atomic
                             secret:
-                              description: Secret containing data to use for the targets.
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must
-                                    be a valid secret key.
                                   type: string
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
-                                    must be defined
                                   type: boolean
                               required:
                               - key
@@ -11818,19 +5832,12 @@ spec:
                               x-kubernetes-map-type: atomic
                           type: object
                         clientSecret:
-                          description: The secret containing the OAuth2 client secret
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
-                                be a valid secret key.
                               type: string
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must
-                                be defined
                               type: boolean
                           required:
                           - key
@@ -11839,15 +5846,12 @@ spec:
                         endpointParams:
                           additionalProperties:
                             type: string
-                          description: Parameters to append to the token URL
                           type: object
                         scopes:
-                          description: OAuth2 scopes used for the token request
                           items:
                             type: string
                           type: array
                         tokenUrl:
-                          description: The URL to fetch the token from
                           minLength: 1
                           type: string
                       required:
@@ -11860,37 +5864,18 @@ spec:
                         items:
                           type: string
                         type: array
-                      description: Optional HTTP URL parameters
                       type: object
                     path:
-                      description: HTTP path to scrape for metrics. If empty, Prometheus
-                        uses the default value (e.g. `/metrics`).
                       type: string
                     port:
-                      description: Name of the pod port this endpoint refers to. Mutually
-                        exclusive with targetPort.
                       type: string
                     proxyUrl:
-                      description: ProxyURL eg http://proxyserver:2195 Directs scrapes
-                        to proxy through this endpoint.
                       type: string
                     relabelings:
-                      description: 'RelabelConfigs to apply to samples before scraping.
-                        Prometheus Operator automatically adds relabelings for a few
-                        standard Kubernetes fields. The original scrape job''s name
-                        is available via the `__tmp_prometheus_job_name` label. More
-                        info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config'
                       items:
-                        description: 'RelabelConfig allows dynamic rewriting of the
-                          label set, being applied to samples before ingestion. It
-                          defines `<metric_relabel_configs>`-section of Prometheus
-                          configuration. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
                         properties:
                           action:
                             default: replace
-                            description: Action to perform based on regex matching.
-                              Default is 'replace'. uppercase and lowercase actions
-                              require Prometheus >= 2.36.
                             enum:
                             - replace
                             - Replace
@@ -11916,104 +5901,59 @@ spec:
                             - DropEqual
                             type: string
                           modulus:
-                            description: Modulus to take of the hash of the source
-                              label values.
                             format: int64
                             type: integer
                           regex:
-                            description: Regular expression against which the extracted
-                              value is matched. Default is '(.*)'
                             type: string
                           replacement:
-                            description: Replacement value against which a regex replace
-                              is performed if the regular expression matches. Regex
-                              capture groups are available. Default is '$1'
                             type: string
                           separator:
-                            description: Separator placed between concatenated source
-                              label values. default is ';'.
                             type: string
                           sourceLabels:
-                            description: The source labels select values from existing
-                              labels. Their content is concatenated using the configured
-                              separator and matched against the configured regular
-                              expression for the replace, keep, and drop actions.
                             items:
-                              description: LabelName is a valid Prometheus label name
-                                which may only contain ASCII letters, numbers, as
-                                well as underscores.
                               pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
                               type: string
                             type: array
                           targetLabel:
-                            description: Label to which the resulting value is written
-                              in a replace action. It is mandatory for replace actions.
-                              Regex capture groups are available.
                             type: string
                         type: object
                       type: array
                     scheme:
-                      description: HTTP scheme to use for scraping. `http` and `https`
-                        are the expected values unless you rewrite the `__scheme__`
-                        label via relabeling. If empty, Prometheus uses the default
-                        value `http`.
                       enum:
                       - http
                       - https
                       type: string
                     scrapeTimeout:
-                      description: Timeout after which the scrape is ended If not
-                        specified, the Prometheus global scrape interval is used.
                       pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                       type: string
                     targetPort:
                       anyOf:
                       - type: integer
                       - type: string
-                      description: 'Deprecated: Use ''port'' instead.'
                       x-kubernetes-int-or-string: true
                     tlsConfig:
-                      description: TLS configuration to use when scraping the endpoint.
                       properties:
                         ca:
-                          description: Certificate authority used when verifying server
-                            certificates.
                           properties:
                             configMap:
-                              description: ConfigMap containing data to use for the
-                                targets.
                               properties:
                                 key:
-                                  description: The key to select.
                                   type: string
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its
-                                    key must be defined
                                   type: boolean
                               required:
                               - key
                               type: object
                               x-kubernetes-map-type: atomic
                             secret:
-                              description: Secret containing data to use for the targets.
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must
-                                    be a valid secret key.
                                   type: string
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
-                                    must be defined
                                   type: boolean
                               required:
                               - key
@@ -12021,43 +5961,26 @@ spec:
                               x-kubernetes-map-type: atomic
                           type: object
                         cert:
-                          description: Client certificate to present when doing client-authentication.
                           properties:
                             configMap:
-                              description: ConfigMap containing data to use for the
-                                targets.
                               properties:
                                 key:
-                                  description: The key to select.
                                   type: string
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its
-                                    key must be defined
                                   type: boolean
                               required:
                               - key
                               type: object
                               x-kubernetes-map-type: atomic
                             secret:
-                              description: Secret containing data to use for the targets.
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must
-                                    be a valid secret key.
                                   type: string
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
-                                    must be defined
                                   type: boolean
                               required:
                               - key
@@ -12065,71 +5988,41 @@ spec:
                               x-kubernetes-map-type: atomic
                           type: object
                         insecureSkipVerify:
-                          description: Disable target certificate validation.
                           type: boolean
                         keySecret:
-                          description: Secret containing the client key file for the
-                            targets.
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
-                                be a valid secret key.
                               type: string
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must
-                                be defined
                               type: boolean
                           required:
                           - key
                           type: object
                           x-kubernetes-map-type: atomic
                         serverName:
-                          description: Used to verify the hostname for the targets.
                           type: string
                       type: object
                   type: object
                 type: array
               podTargetLabels:
-                description: PodTargetLabels transfers labels on the Kubernetes Pod
-                  onto the target.
                 items:
                   type: string
                 type: array
               sampleLimit:
-                description: SampleLimit defines per-scrape limit on number of scraped
-                  samples that will be accepted.
                 format: int64
                 type: integer
               selector:
-                description: Selector to select Pod objects.
                 properties:
                   matchExpressions:
-                    description: matchExpressions is a list of label selector requirements.
-                      The requirements are ANDed.
                     items:
-                      description: A label selector requirement is a selector that
-                        contains values, a key, and an operator that relates the key
-                        and values.
                       properties:
                         key:
-                          description: key is the label key that the selector applies
-                            to.
                           type: string
                         operator:
-                          description: operator represents a key's relationship to
-                            a set of values. Valid operators are In, NotIn, Exists
-                            and DoesNotExist.
                           type: string
                         values:
-                          description: values is an array of string values. If the
-                            operator is In or NotIn, the values array must be non-empty.
-                            If the operator is Exists or DoesNotExist, the values
-                            array must be empty. This array is replaced during a strategic
-                            merge patch.
                           items:
                             type: string
                           type: array
@@ -12141,17 +6034,10 @@ spec:
                   matchLabels:
                     additionalProperties:
                       type: string
-                    description: matchLabels is a map of {key,value} pairs. A single
-                      {key,value} in the matchLabels map is equivalent to an element
-                      of matchExpressions, whose key field is "key", the operator
-                      is "In", and the values array contains only "value". The requirements
-                      are ANDed.
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
               targetLimit:
-                description: TargetLimit defines a limit on the number of scraped
-                  targets that will be accepted.
                 format: int64
                 type: integer
             required:
@@ -12187,91 +6073,53 @@ spec:
   - name: v1
     schema:
       openAPIV3Schema:
-        description: Probe defines monitoring for a set of static targets or ingresses.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           spec:
-            description: Specification of desired Ingress selection for target discovery
-              by Prometheus.
             properties:
               authorization:
-                description: Authorization section for this endpoint
                 properties:
                   credentials:
-                    description: The secret's key that contains the credentials of
-                      the request
                     properties:
                       key:
-                        description: The key of the secret to select from.  Must be
-                          a valid secret key.
                         type: string
                       name:
-                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                          TODO: Add other useful fields. apiVersion, kind, uid?'
                         type: string
                       optional:
-                        description: Specify whether the Secret or its key must be
-                          defined
                         type: boolean
                     required:
                     - key
                     type: object
                     x-kubernetes-map-type: atomic
                   type:
-                    description: Set the authentication type. Defaults to Bearer,
-                      Basic will cause an error
                     type: string
                 type: object
               basicAuth:
-                description: 'BasicAuth allow an endpoint to authenticate over basic
-                  authentication. More info: https://prometheus.io/docs/operating/configuration/#endpoint'
                 properties:
                   password:
-                    description: The secret in the service monitor namespace that
-                      contains the password for authentication.
                     properties:
                       key:
-                        description: The key of the secret to select from.  Must be
-                          a valid secret key.
                         type: string
                       name:
-                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                          TODO: Add other useful fields. apiVersion, kind, uid?'
                         type: string
                       optional:
-                        description: Specify whether the Secret or its key must be
-                          defined
                         type: boolean
                     required:
                     - key
                     type: object
                     x-kubernetes-map-type: atomic
                   username:
-                    description: The secret in the service monitor namespace that
-                      contains the username for authentication.
                     properties:
                       key:
-                        description: The key of the secret to select from.  Must be
-                          a valid secret key.
                         type: string
                       name:
-                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                          TODO: Add other useful fields. apiVersion, kind, uid?'
                         type: string
                       optional:
-                        description: Specify whether the Secret or its key must be
-                          defined
                         type: boolean
                     required:
                     - key
@@ -12279,62 +6127,36 @@ spec:
                     x-kubernetes-map-type: atomic
                 type: object
               bearerTokenSecret:
-                description: Secret to mount to read bearer token for scraping targets.
-                  The secret needs to be in the same namespace as the probe and accessible
-                  by the Prometheus Operator.
                 properties:
                   key:
-                    description: The key of the secret to select from.  Must be a
-                      valid secret key.
                     type: string
                   name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                      TODO: Add other useful fields. apiVersion, kind, uid?'
                     type: string
                   optional:
-                    description: Specify whether the Secret or its key must be defined
                     type: boolean
                 required:
                 - key
                 type: object
                 x-kubernetes-map-type: atomic
               interval:
-                description: Interval at which targets are probed using the configured
-                  prober. If not specified Prometheus' global scrape interval is used.
                 pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                 type: string
               jobName:
-                description: The job name assigned to scraped metrics by default.
                 type: string
               labelLimit:
-                description: Per-scrape limit on number of labels that will be accepted
-                  for a sample. Only valid in Prometheus versions 2.27.0 and newer.
                 format: int64
                 type: integer
               labelNameLengthLimit:
-                description: Per-scrape limit on length of labels name that will be
-                  accepted for a sample. Only valid in Prometheus versions 2.27.0
-                  and newer.
                 format: int64
                 type: integer
               labelValueLengthLimit:
-                description: Per-scrape limit on length of labels value that will
-                  be accepted for a sample. Only valid in Prometheus versions 2.27.0
-                  and newer.
                 format: int64
                 type: integer
               metricRelabelings:
-                description: MetricRelabelConfigs to apply to samples before ingestion.
                 items:
-                  description: 'RelabelConfig allows dynamic rewriting of the label
-                    set, being applied to samples before ingestion. It defines `<metric_relabel_configs>`-section
-                    of Prometheus configuration. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
                   properties:
                     action:
                       default: replace
-                      description: Action to perform based on regex matching. Default
-                        is 'replace'. uppercase and lowercase actions require Prometheus
-                        >= 2.36.
                       enum:
                       - replace
                       - Replace
@@ -12360,86 +6182,48 @@ spec:
                       - DropEqual
                       type: string
                     modulus:
-                      description: Modulus to take of the hash of the source label
-                        values.
                       format: int64
                       type: integer
                     regex:
-                      description: Regular expression against which the extracted
-                        value is matched. Default is '(.*)'
                       type: string
                     replacement:
-                      description: Replacement value against which a regex replace
-                        is performed if the regular expression matches. Regex capture
-                        groups are available. Default is '$1'
                       type: string
                     separator:
-                      description: Separator placed between concatenated source label
-                        values. default is ';'.
                       type: string
                     sourceLabels:
-                      description: The source labels select values from existing labels.
-                        Their content is concatenated using the configured separator
-                        and matched against the configured regular expression for
-                        the replace, keep, and drop actions.
                       items:
-                        description: LabelName is a valid Prometheus label name which
-                          may only contain ASCII letters, numbers, as well as underscores.
                         pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
                         type: string
                       type: array
                     targetLabel:
-                      description: Label to which the resulting value is written in
-                        a replace action. It is mandatory for replace actions. Regex
-                        capture groups are available.
                       type: string
                   type: object
                 type: array
               module:
-                description: 'The module to use for probing specifying how to probe
-                  the target. Example module configuring in the blackbox exporter:
-                  https://github.com/prometheus/blackbox_exporter/blob/master/example.yml'
                 type: string
               oauth2:
-                description: OAuth2 for the URL. Only valid in Prometheus versions
-                  2.27.0 and newer.
                 properties:
                   clientId:
-                    description: The secret or configmap containing the OAuth2 client
-                      id
                     properties:
                       configMap:
-                        description: ConfigMap containing data to use for the targets.
                         properties:
                           key:
-                            description: The key to select.
                             type: string
                           name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                           optional:
-                            description: Specify whether the ConfigMap or its key
-                              must be defined
                             type: boolean
                         required:
                         - key
                         type: object
                         x-kubernetes-map-type: atomic
                       secret:
-                        description: Secret containing data to use for the targets.
                         properties:
                           key:
-                            description: The key of the secret to select from.  Must
-                              be a valid secret key.
                             type: string
                           name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                           optional:
-                            description: Specify whether the Secret or its key must
-                              be defined
                             type: boolean
                         required:
                         - key
@@ -12447,19 +6231,12 @@ spec:
                         x-kubernetes-map-type: atomic
                     type: object
                   clientSecret:
-                    description: The secret containing the OAuth2 client secret
                     properties:
                       key:
-                        description: The key of the secret to select from.  Must be
-                          a valid secret key.
                         type: string
                       name:
-                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                          TODO: Add other useful fields. apiVersion, kind, uid?'
                         type: string
                       optional:
-                        description: Specify whether the Secret or its key must be
-                          defined
                         type: boolean
                     required:
                     - key
@@ -12468,15 +6245,12 @@ spec:
                   endpointParams:
                     additionalProperties:
                       type: string
-                    description: Parameters to append to the token URL
                     type: object
                   scopes:
-                    description: OAuth2 scopes used for the token request
                     items:
                       type: string
                     type: array
                   tokenUrl:
-                    description: The URL to fetch the token from
                     minLength: 1
                     type: string
                 required:
@@ -12485,87 +6259,49 @@ spec:
                 - tokenUrl
                 type: object
               prober:
-                description: Specification for the prober to use for probing targets.
-                  The prober.URL parameter is required. Targets cannot be probed if
-                  left empty.
                 properties:
                   path:
                     default: /probe
-                    description: Path to collect metrics from. Defaults to `/probe`.
                     type: string
                   proxyUrl:
-                    description: Optional ProxyURL.
                     type: string
                   scheme:
-                    description: HTTP scheme to use for scraping. `http` and `https`
-                      are the expected values unless you rewrite the `__scheme__`
-                      label via relabeling. If empty, Prometheus uses the default
-                      value `http`.
                     enum:
                     - http
                     - https
                     type: string
                   url:
-                    description: Mandatory URL of the prober.
                     type: string
                 required:
                 - url
                 type: object
               sampleLimit:
-                description: SampleLimit defines per-scrape limit on number of scraped
-                  samples that will be accepted.
                 format: int64
                 type: integer
               scrapeTimeout:
-                description: Timeout for scraping metrics from the Prometheus exporter.
-                  If not specified, the Prometheus global scrape timeout is used.
                 pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                 type: string
               targetLimit:
-                description: TargetLimit defines a limit on the number of scraped
-                  targets that will be accepted.
                 format: int64
                 type: integer
               targets:
-                description: Targets defines a set of static or dynamically discovered
-                  targets to probe.
                 properties:
                   ingress:
-                    description: ingress defines the Ingress objects to probe and
-                      the relabeling configuration. If `staticConfig` is also defined,
-                      `staticConfig` takes precedence.
                     properties:
                       namespaceSelector:
-                        description: From which namespaces to select Ingress objects.
                         properties:
                           any:
-                            description: Boolean describing whether all namespaces
-                              are selected in contrast to a list restricting them.
                             type: boolean
                           matchNames:
-                            description: List of namespace names to select from.
                             items:
                               type: string
                             type: array
                         type: object
                       relabelingConfigs:
-                        description: 'RelabelConfigs to apply to the label set of
-                          the target before it gets scraped. The original ingress
-                          address is available via the `__tmp_prometheus_ingress_address`
-                          label. It can be used to customize the probed URL. The original
-                          scrape job''s name is available via the `__tmp_prometheus_job_name`
-                          label. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config'
                         items:
-                          description: 'RelabelConfig allows dynamic rewriting of
-                            the label set, being applied to samples before ingestion.
-                            It defines `<metric_relabel_configs>`-section of Prometheus
-                            configuration. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
                           properties:
                             action:
                               default: replace
-                              description: Action to perform based on regex matching.
-                                Default is 'replace'. uppercase and lowercase actions
-                                require Prometheus >= 2.36.
                               enum:
                               - replace
                               - Replace
@@ -12591,69 +6327,33 @@ spec:
                               - DropEqual
                               type: string
                             modulus:
-                              description: Modulus to take of the hash of the source
-                                label values.
                               format: int64
                               type: integer
                             regex:
-                              description: Regular expression against which the extracted
-                                value is matched. Default is '(.*)'
                               type: string
                             replacement:
-                              description: Replacement value against which a regex
-                                replace is performed if the regular expression matches.
-                                Regex capture groups are available. Default is '$1'
                               type: string
                             separator:
-                              description: Separator placed between concatenated source
-                                label values. default is ';'.
                               type: string
                             sourceLabels:
-                              description: The source labels select values from existing
-                                labels. Their content is concatenated using the configured
-                                separator and matched against the configured regular
-                                expression for the replace, keep, and drop actions.
                               items:
-                                description: LabelName is a valid Prometheus label
-                                  name which may only contain ASCII letters, numbers,
-                                  as well as underscores.
                                 pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
                                 type: string
                               type: array
                             targetLabel:
-                              description: Label to which the resulting value is written
-                                in a replace action. It is mandatory for replace actions.
-                                Regex capture groups are available.
                               type: string
                           type: object
                         type: array
                       selector:
-                        description: Selector to select the Ingress objects.
                         properties:
                           matchExpressions:
-                            description: matchExpressions is a list of label selector
-                              requirements. The requirements are ANDed.
                             items:
-                              description: A label selector requirement is a selector
-                                that contains values, a key, and an operator that
-                                relates the key and values.
                               properties:
                                 key:
-                                  description: key is the label key that the selector
-                                    applies to.
                                   type: string
                                 operator:
-                                  description: operator represents a key's relationship
-                                    to a set of values. Valid operators are In, NotIn,
-                                    Exists and DoesNotExist.
                                   type: string
                                 values:
-                                  description: values is an array of string values.
-                                    If the operator is In or NotIn, the values array
-                                    must be non-empty. If the operator is Exists or
-                                    DoesNotExist, the values array must be empty.
-                                    This array is replaced during a strategic merge
-                                    patch.
                                   items:
                                     type: string
                                   type: array
@@ -12665,40 +6365,21 @@ spec:
                           matchLabels:
                             additionalProperties:
                               type: string
-                            description: matchLabels is a map of {key,value} pairs.
-                              A single {key,value} in the matchLabels map is equivalent
-                              to an element of matchExpressions, whose key field is
-                              "key", the operator is "In", and the values array contains
-                              only "value". The requirements are ANDed.
                             type: object
                         type: object
                         x-kubernetes-map-type: atomic
                     type: object
                   staticConfig:
-                    description: 'staticConfig defines the static list of targets
-                      to probe and the relabeling configuration. If `ingress` is also
-                      defined, `staticConfig` takes precedence. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#static_config.'
                     properties:
                       labels:
                         additionalProperties:
                           type: string
-                        description: Labels assigned to all metrics scraped from the
-                          targets.
                         type: object
                       relabelingConfigs:
-                        description: 'RelabelConfigs to apply to the label set of
-                          the targets before it gets scraped. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config'
                         items:
-                          description: 'RelabelConfig allows dynamic rewriting of
-                            the label set, being applied to samples before ingestion.
-                            It defines `<metric_relabel_configs>`-section of Prometheus
-                            configuration. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
                           properties:
                             action:
                               default: replace
-                              description: Action to perform based on regex matching.
-                                Default is 'replace'. uppercase and lowercase actions
-                                require Prometheus >= 2.36.
                               enum:
                               - replace
                               - Replace
@@ -12724,88 +6405,52 @@ spec:
                               - DropEqual
                               type: string
                             modulus:
-                              description: Modulus to take of the hash of the source
-                                label values.
                               format: int64
                               type: integer
                             regex:
-                              description: Regular expression against which the extracted
-                                value is matched. Default is '(.*)'
                               type: string
                             replacement:
-                              description: Replacement value against which a regex
-                                replace is performed if the regular expression matches.
-                                Regex capture groups are available. Default is '$1'
                               type: string
                             separator:
-                              description: Separator placed between concatenated source
-                                label values. default is ';'.
                               type: string
                             sourceLabels:
-                              description: The source labels select values from existing
-                                labels. Their content is concatenated using the configured
-                                separator and matched against the configured regular
-                                expression for the replace, keep, and drop actions.
                               items:
-                                description: LabelName is a valid Prometheus label
-                                  name which may only contain ASCII letters, numbers,
-                                  as well as underscores.
                                 pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
                                 type: string
                               type: array
                             targetLabel:
-                              description: Label to which the resulting value is written
-                                in a replace action. It is mandatory for replace actions.
-                                Regex capture groups are available.
                               type: string
                           type: object
                         type: array
                       static:
-                        description: The list of hosts to probe.
                         items:
                           type: string
                         type: array
                     type: object
                 type: object
               tlsConfig:
-                description: TLS configuration to use when scraping the endpoint.
                 properties:
                   ca:
-                    description: Certificate authority used when verifying server
-                      certificates.
                     properties:
                       configMap:
-                        description: ConfigMap containing data to use for the targets.
                         properties:
                           key:
-                            description: The key to select.
                             type: string
                           name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                           optional:
-                            description: Specify whether the ConfigMap or its key
-                              must be defined
                             type: boolean
                         required:
                         - key
                         type: object
                         x-kubernetes-map-type: atomic
                       secret:
-                        description: Secret containing data to use for the targets.
                         properties:
                           key:
-                            description: The key of the secret to select from.  Must
-                              be a valid secret key.
                             type: string
                           name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                           optional:
-                            description: Specify whether the Secret or its key must
-                              be defined
                             type: boolean
                         required:
                         - key
@@ -12813,40 +6458,26 @@ spec:
                         x-kubernetes-map-type: atomic
                     type: object
                   cert:
-                    description: Client certificate to present when doing client-authentication.
                     properties:
                       configMap:
-                        description: ConfigMap containing data to use for the targets.
                         properties:
                           key:
-                            description: The key to select.
                             type: string
                           name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                           optional:
-                            description: Specify whether the ConfigMap or its key
-                              must be defined
                             type: boolean
                         required:
                         - key
                         type: object
                         x-kubernetes-map-type: atomic
                       secret:
-                        description: Secret containing data to use for the targets.
                         properties:
                           key:
-                            description: The key of the secret to select from.  Must
-                              be a valid secret key.
                             type: string
                           name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                           optional:
-                            description: Specify whether the Secret or its key must
-                              be defined
                             type: boolean
                         required:
                         - key
@@ -12854,29 +6485,20 @@ spec:
                         x-kubernetes-map-type: atomic
                     type: object
                   insecureSkipVerify:
-                    description: Disable target certificate validation.
                     type: boolean
                   keySecret:
-                    description: Secret containing the client key file for the targets.
                     properties:
                       key:
-                        description: The key of the secret to select from.  Must be
-                          a valid secret key.
                         type: string
                       name:
-                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                          TODO: Add other useful fields. apiVersion, kind, uid?'
                         type: string
                       optional:
-                        description: Specify whether the Secret or its key must be
-                          defined
                         type: boolean
                     required:
                     - key
                     type: object
                     x-kubernetes-map-type: atomic
                   serverName:
-                    description: Used to verify the hostname for the targets.
                     type: string
                 type: object
             type: object
@@ -12909,106 +6531,61 @@ spec:
   - name: v1
     schema:
       openAPIV3Schema:
-        description: ServiceMonitor defines monitoring for a set of services.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           spec:
-            description: Specification of desired Service selection for target discovery
-              by Prometheus.
             properties:
               attachMetadata:
-                description: Attaches node metadata to discovered targets. Requires
-                  Prometheus v2.37.0 and above.
                 properties:
                   node:
-                    description: When set to true, Prometheus must have permissions
-                      to get Nodes.
                     type: boolean
                 type: object
               endpoints:
-                description: A list of endpoints allowed as part of this ServiceMonitor.
                 items:
-                  description: Endpoint defines a scrapeable endpoint serving Prometheus
-                    metrics.
                   properties:
                     authorization:
-                      description: Authorization section for this endpoint
                       properties:
                         credentials:
-                          description: The secret's key that contains the credentials
-                            of the request
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
-                                be a valid secret key.
                               type: string
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must
-                                be defined
                               type: boolean
                           required:
                           - key
                           type: object
                           x-kubernetes-map-type: atomic
                         type:
-                          description: Set the authentication type. Defaults to Bearer,
-                            Basic will cause an error
                           type: string
                       type: object
                     basicAuth:
-                      description: 'BasicAuth allow an endpoint to authenticate over
-                        basic authentication More info: https://prometheus.io/docs/operating/configuration/#endpoints'
                       properties:
                         password:
-                          description: The secret in the service monitor namespace
-                            that contains the password for authentication.
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
-                                be a valid secret key.
                               type: string
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must
-                                be defined
                               type: boolean
                           required:
                           - key
                           type: object
                           x-kubernetes-map-type: atomic
                         username:
-                          description: The secret in the service monitor namespace
-                            that contains the username for authentication.
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
-                                be a valid secret key.
                               type: string
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must
-                                be defined
                               type: boolean
                           required:
                           - key
@@ -13016,67 +6593,37 @@ spec:
                           x-kubernetes-map-type: atomic
                       type: object
                     bearerTokenFile:
-                      description: File to read bearer token for scraping targets.
                       type: string
                     bearerTokenSecret:
-                      description: Secret to mount to read bearer token for scraping
-                        targets. The secret needs to be in the same namespace as the
-                        service monitor and accessible by the Prometheus Operator.
                       properties:
                         key:
-                          description: The key of the secret to select from.  Must
-                            be a valid secret key.
                           type: string
                         name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?'
                           type: string
                         optional:
-                          description: Specify whether the Secret or its key must
-                            be defined
                           type: boolean
                       required:
                       - key
                       type: object
                       x-kubernetes-map-type: atomic
                     enableHttp2:
-                      description: Whether to enable HTTP2.
                       type: boolean
                     filterRunning:
-                      description: 'Drop pods that are not running. (Failed, Succeeded).
-                        Enabled by default. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase'
                       type: boolean
                     followRedirects:
-                      description: FollowRedirects configures whether scrape requests
-                        follow HTTP 3xx redirects.
                       type: boolean
                     honorLabels:
-                      description: HonorLabels chooses the metric's labels on collisions
-                        with target labels.
                       type: boolean
                     honorTimestamps:
-                      description: HonorTimestamps controls whether Prometheus respects
-                        the timestamps present in scraped data.
                       type: boolean
                     interval:
-                      description: Interval at which metrics should be scraped If
-                        not specified Prometheus' global scrape interval is used.
                       pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                       type: string
                     metricRelabelings:
-                      description: MetricRelabelConfigs to apply to samples before
-                        ingestion.
                       items:
-                        description: 'RelabelConfig allows dynamic rewriting of the
-                          label set, being applied to samples before ingestion. It
-                          defines `<metric_relabel_configs>`-section of Prometheus
-                          configuration. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
                         properties:
                           action:
                             default: replace
-                            description: Action to perform based on regex matching.
-                              Default is 'replace'. uppercase and lowercase actions
-                              require Prometheus >= 2.36.
                             enum:
                             - replace
                             - Replace
@@ -13102,85 +6649,46 @@ spec:
                             - DropEqual
                             type: string
                           modulus:
-                            description: Modulus to take of the hash of the source
-                              label values.
                             format: int64
                             type: integer
                           regex:
-                            description: Regular expression against which the extracted
-                              value is matched. Default is '(.*)'
                             type: string
                           replacement:
-                            description: Replacement value against which a regex replace
-                              is performed if the regular expression matches. Regex
-                              capture groups are available. Default is '$1'
                             type: string
                           separator:
-                            description: Separator placed between concatenated source
-                              label values. default is ';'.
                             type: string
                           sourceLabels:
-                            description: The source labels select values from existing
-                              labels. Their content is concatenated using the configured
-                              separator and matched against the configured regular
-                              expression for the replace, keep, and drop actions.
                             items:
-                              description: LabelName is a valid Prometheus label name
-                                which may only contain ASCII letters, numbers, as
-                                well as underscores.
                               pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
                               type: string
                             type: array
                           targetLabel:
-                            description: Label to which the resulting value is written
-                              in a replace action. It is mandatory for replace actions.
-                              Regex capture groups are available.
                             type: string
                         type: object
                       type: array
                     oauth2:
-                      description: OAuth2 for the URL. Only valid in Prometheus versions
-                        2.27.0 and newer.
                       properties:
                         clientId:
-                          description: The secret or configmap containing the OAuth2
-                            client id
                           properties:
                             configMap:
-                              description: ConfigMap containing data to use for the
-                                targets.
                               properties:
                                 key:
-                                  description: The key to select.
                                   type: string
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its
-                                    key must be defined
                                   type: boolean
                               required:
                               - key
                               type: object
                               x-kubernetes-map-type: atomic
                             secret:
-                              description: Secret containing data to use for the targets.
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must
-                                    be a valid secret key.
                                   type: string
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
-                                    must be defined
                                   type: boolean
                               required:
                               - key
@@ -13188,19 +6696,12 @@ spec:
                               x-kubernetes-map-type: atomic
                           type: object
                         clientSecret:
-                          description: The secret containing the OAuth2 client secret
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
-                                be a valid secret key.
                               type: string
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must
-                                be defined
                               type: boolean
                           required:
                           - key
@@ -13209,15 +6710,12 @@ spec:
                         endpointParams:
                           additionalProperties:
                             type: string
-                          description: Parameters to append to the token URL
                           type: object
                         scopes:
-                          description: OAuth2 scopes used for the token request
                           items:
                             type: string
                           type: array
                         tokenUrl:
-                          description: The URL to fetch the token from
                           minLength: 1
                           type: string
                       required:
@@ -13230,37 +6728,18 @@ spec:
                         items:
                           type: string
                         type: array
-                      description: Optional HTTP URL parameters
                       type: object
                     path:
-                      description: HTTP path to scrape for metrics. If empty, Prometheus
-                        uses the default value (e.g. `/metrics`).
                       type: string
                     port:
-                      description: Name of the service port this endpoint refers to.
-                        Mutually exclusive with targetPort.
                       type: string
                     proxyUrl:
-                      description: ProxyURL eg http://proxyserver:2195 Directs scrapes
-                        to proxy through this endpoint.
                       type: string
                     relabelings:
-                      description: 'RelabelConfigs to apply to samples before scraping.
-                        Prometheus Operator automatically adds relabelings for a few
-                        standard Kubernetes fields. The original scrape job''s name
-                        is available via the `__tmp_prometheus_job_name` label. More
-                        info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config'
                       items:
-                        description: 'RelabelConfig allows dynamic rewriting of the
-                          label set, being applied to samples before ingestion. It
-                          defines `<metric_relabel_configs>`-section of Prometheus
-                          configuration. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
                         properties:
                           action:
                             default: replace
-                            description: Action to perform based on regex matching.
-                              Default is 'replace'. uppercase and lowercase actions
-                              require Prometheus >= 2.36.
                             enum:
                             - replace
                             - Replace
@@ -13286,107 +6765,59 @@ spec:
                             - DropEqual
                             type: string
                           modulus:
-                            description: Modulus to take of the hash of the source
-                              label values.
                             format: int64
                             type: integer
                           regex:
-                            description: Regular expression against which the extracted
-                              value is matched. Default is '(.*)'
                             type: string
                           replacement:
-                            description: Replacement value against which a regex replace
-                              is performed if the regular expression matches. Regex
-                              capture groups are available. Default is '$1'
                             type: string
                           separator:
-                            description: Separator placed between concatenated source
-                              label values. default is ';'.
                             type: string
                           sourceLabels:
-                            description: The source labels select values from existing
-                              labels. Their content is concatenated using the configured
-                              separator and matched against the configured regular
-                              expression for the replace, keep, and drop actions.
                             items:
-                              description: LabelName is a valid Prometheus label name
-                                which may only contain ASCII letters, numbers, as
-                                well as underscores.
                               pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
                               type: string
                             type: array
                           targetLabel:
-                            description: Label to which the resulting value is written
-                              in a replace action. It is mandatory for replace actions.
-                              Regex capture groups are available.
                             type: string
                         type: object
                       type: array
                     scheme:
-                      description: HTTP scheme to use for scraping. `http` and `https`
-                        are the expected values unless you rewrite the `__scheme__`
-                        label via relabeling. If empty, Prometheus uses the default
-                        value `http`.
                       enum:
                       - http
                       - https
                       type: string
                     scrapeTimeout:
-                      description: Timeout after which the scrape is ended If not
-                        specified, the Prometheus global scrape timeout is used unless
-                        it is less than `Interval` in which the latter is used.
                       pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                       type: string
                     targetPort:
                       anyOf:
                       - type: integer
                       - type: string
-                      description: Name or number of the target port of the Pod behind
-                        the Service, the port must be specified with container port
-                        property. Mutually exclusive with port.
                       x-kubernetes-int-or-string: true
                     tlsConfig:
-                      description: TLS configuration to use when scraping the endpoint
                       properties:
                         ca:
-                          description: Certificate authority used when verifying server
-                            certificates.
                           properties:
                             configMap:
-                              description: ConfigMap containing data to use for the
-                                targets.
                               properties:
                                 key:
-                                  description: The key to select.
                                   type: string
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its
-                                    key must be defined
                                   type: boolean
                               required:
                               - key
                               type: object
                               x-kubernetes-map-type: atomic
                             secret:
-                              description: Secret containing data to use for the targets.
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must
-                                    be a valid secret key.
                                   type: string
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
-                                    must be defined
                                   type: boolean
                               required:
                               - key
@@ -13394,47 +6825,28 @@ spec:
                               x-kubernetes-map-type: atomic
                           type: object
                         caFile:
-                          description: Path to the CA cert in the Prometheus container
-                            to use for the targets.
                           type: string
                         cert:
-                          description: Client certificate to present when doing client-authentication.
                           properties:
                             configMap:
-                              description: ConfigMap containing data to use for the
-                                targets.
                               properties:
                                 key:
-                                  description: The key to select.
                                   type: string
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its
-                                    key must be defined
                                   type: boolean
                               required:
                               - key
                               type: object
                               x-kubernetes-map-type: atomic
                             secret:
-                              description: Secret containing data to use for the targets.
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must
-                                    be a valid secret key.
                                   type: string
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
-                                    must be defined
                                   type: boolean
                               required:
                               - key
@@ -13442,119 +6854,65 @@ spec:
                               x-kubernetes-map-type: atomic
                           type: object
                         certFile:
-                          description: Path to the client cert file in the Prometheus
-                            container for the targets.
                           type: string
                         insecureSkipVerify:
-                          description: Disable target certificate validation.
                           type: boolean
                         keyFile:
-                          description: Path to the client key file in the Prometheus
-                            container for the targets.
                           type: string
                         keySecret:
-                          description: Secret containing the client key file for the
-                            targets.
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
-                                be a valid secret key.
                               type: string
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
                             optional:
-                              description: Specify whether the Secret or its key must
-                                be defined
                               type: boolean
                           required:
                           - key
                           type: object
                           x-kubernetes-map-type: atomic
                         serverName:
-                          description: Used to verify the hostname for the targets.
                           type: string
                       type: object
                   type: object
                 type: array
               jobLabel:
-                description: "JobLabel selects the label from the associated Kubernetes
-                  service which will be used as the `job` label for all metrics. \n
-                  For example: If in `ServiceMonitor.spec.jobLabel: foo` and in `Service.metadata.labels.foo:
-                  bar`, then the `job=\"bar\"` label is added to all metrics. \n If
-                  the value of this field is empty or if the label doesn't exist for
-                  the given Service, the `job` label of the metrics defaults to the
-                  name of the Kubernetes Service."
                 type: string
               labelLimit:
-                description: Per-scrape limit on number of labels that will be accepted
-                  for a sample. Only valid in Prometheus versions 2.27.0 and newer.
                 format: int64
                 type: integer
               labelNameLengthLimit:
-                description: Per-scrape limit on length of labels name that will be
-                  accepted for a sample. Only valid in Prometheus versions 2.27.0
-                  and newer.
                 format: int64
                 type: integer
               labelValueLengthLimit:
-                description: Per-scrape limit on length of labels value that will
-                  be accepted for a sample. Only valid in Prometheus versions 2.27.0
-                  and newer.
                 format: int64
                 type: integer
               namespaceSelector:
-                description: Selector to select which namespaces the Kubernetes Endpoints
-                  objects are discovered from.
                 properties:
                   any:
-                    description: Boolean describing whether all namespaces are selected
-                      in contrast to a list restricting them.
                     type: boolean
                   matchNames:
-                    description: List of namespace names to select from.
                     items:
                       type: string
                     type: array
                 type: object
               podTargetLabels:
-                description: PodTargetLabels transfers labels on the Kubernetes `Pod`
-                  onto the created metrics.
                 items:
                   type: string
                 type: array
               sampleLimit:
-                description: SampleLimit defines per-scrape limit on number of scraped
-                  samples that will be accepted.
                 format: int64
                 type: integer
               selector:
-                description: Selector to select Endpoints objects.
                 properties:
                   matchExpressions:
-                    description: matchExpressions is a list of label selector requirements.
-                      The requirements are ANDed.
                     items:
-                      description: A label selector requirement is a selector that
-                        contains values, a key, and an operator that relates the key
-                        and values.
                       properties:
                         key:
-                          description: key is the label key that the selector applies
-                            to.
                           type: string
                         operator:
-                          description: operator represents a key's relationship to
-                            a set of values. Valid operators are In, NotIn, Exists
-                            and DoesNotExist.
                           type: string
                         values:
-                          description: values is an array of string values. If the
-                            operator is In or NotIn, the values array must be non-empty.
-                            If the operator is Exists or DoesNotExist, the values
-                            array must be empty. This array is replaced during a strategic
-                            merge patch.
                           items:
                             type: string
                           type: array
@@ -13566,23 +6924,14 @@ spec:
                   matchLabels:
                     additionalProperties:
                       type: string
-                    description: matchLabels is a map of {key,value} pairs. A single
-                      {key,value} in the matchLabels map is equivalent to an element
-                      of matchExpressions, whose key field is "key", the operator
-                      is "In", and the values array contains only "value". The requirements
-                      are ANDed.
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
               targetLabels:
-                description: TargetLabels transfers labels from the Kubernetes `Service`
-                  onto the created metrics.
                 items:
                   type: string
                 type: array
               targetLimit:
-                description: TargetLimit defines a limit on the number of scraped
-                  targets that will be accepted.
                 format: int64
                 type: integer
             required:
@@ -13603,8 +6952,8 @@ metadata:
     app.kubernetes.io/instance: grafana-agent-operator
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: grafana-agent-operator
-    app.kubernetes.io/version: 0.39.1
-    helm.sh/chart: grafana-agent-operator-0.3.15
+    app.kubernetes.io/version: 0.41.1
+    helm.sh/chart: grafana-agent-operator-0.4.0
   name: grafana-agent-operator
   namespace: grafana-agent
 ---
@@ -13618,7 +6967,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/version: 2.12.0
-    helm.sh/chart: kube-state-metrics-5.20.0
+    helm.sh/chart: kube-state-metrics-5.20.1
   name: ksm-kube-state-metrics
   namespace: kube-system
 ---
@@ -13630,8 +6979,8 @@ metadata:
     app.kubernetes.io/instance: grafana-agent-operator
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: grafana-agent-operator
-    app.kubernetes.io/version: 0.39.1
-    helm.sh/chart: grafana-agent-operator-0.3.15
+    app.kubernetes.io/version: 0.41.1
+    helm.sh/chart: grafana-agent-operator-0.4.0
   name: grafana-agent-operator
 rules:
 - apiGroups:
@@ -13729,7 +7078,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/version: 2.12.0
-    helm.sh/chart: kube-state-metrics-5.20.0
+    helm.sh/chart: kube-state-metrics-5.20.1
   name: ksm-kube-state-metrics
 rules:
 - apiGroups:
@@ -13941,8 +7290,8 @@ metadata:
     app.kubernetes.io/instance: grafana-agent-operator
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: grafana-agent-operator
-    app.kubernetes.io/version: 0.39.1
-    helm.sh/chart: grafana-agent-operator-0.3.15
+    app.kubernetes.io/version: 0.41.1
+    helm.sh/chart: grafana-agent-operator-0.4.0
   name: grafana-agent-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13963,7 +7312,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/version: 2.12.0
-    helm.sh/chart: kube-state-metrics-5.20.0
+    helm.sh/chart: kube-state-metrics-5.20.1
   name: ksm-kube-state-metrics
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13986,7 +7335,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/version: 2.12.0
-    helm.sh/chart: kube-state-metrics-5.20.0
+    helm.sh/chart: kube-state-metrics-5.20.1
   name: ksm-kube-state-metrics
   namespace: kube-system
 spec:
@@ -14008,8 +7357,8 @@ metadata:
     app.kubernetes.io/instance: grafana-agent-operator
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: grafana-agent-operator
-    app.kubernetes.io/version: 0.39.1
-    helm.sh/chart: grafana-agent-operator-0.3.15
+    app.kubernetes.io/version: 0.41.1
+    helm.sh/chart: grafana-agent-operator-0.4.0
   name: grafana-agent-operator
   namespace: grafana-agent
 spec:
@@ -14027,7 +7376,7 @@ spec:
       containers:
       - args:
         - --kubelet-service=default/kubelet
-        image: docker.io/grafana/agent-operator:v0.41.1
+        image: docker.io/grafana/agent-operator:v0.42.0
         imagePullPolicy: IfNotPresent
         name: grafana-agent-operator
         resources:
@@ -14046,7 +7395,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/version: 2.12.0
-    helm.sh/chart: kube-state-metrics-5.20.0
+    helm.sh/chart: kube-state-metrics-5.20.1
   name: ksm-kube-state-metrics
   namespace: kube-system
 spec:
@@ -14067,7 +7416,7 @@ spec:
         app.kubernetes.io/name: kube-state-metrics
         app.kubernetes.io/part-of: kube-state-metrics
         app.kubernetes.io/version: 2.12.0
-        helm.sh/chart: kube-state-metrics-5.20.0
+        helm.sh/chart: kube-state-metrics-5.20.1
     spec:
       containers:
       - args:

--- a/grafana/operator-values.yaml
+++ b/grafana/operator-values.yaml
@@ -1,5 +1,5 @@
 image:
-  tag: v0.41.1
+  tag: v0.42.0
 resources:
   requests:
     memory: 30Mi

--- a/locals.tf
+++ b/locals.tf
@@ -1,6 +1,6 @@
 locals {
   version       = "0.42.0"
-  agent_version = "0.41.1"
+  agent_version = "0.42.0"
   yaml = templatefile("${path.module}/custom-resources.yaml.tmpl", {
     cluster_name         = var.cluster_name
     external_labels      = merge({ cluster = var.cluster_name }, var.external_labels)

--- a/locals.tf
+++ b/locals.tf
@@ -1,5 +1,5 @@
 locals {
-  version       = "0.41.1"
+  version       = "0.42.0"
   agent_version = "0.41.1"
   yaml = templatefile("${path.module}/custom-resources.yaml.tmpl", {
     cluster_name         = var.cluster_name


### PR DESCRIPTION



<Actions>
    <action id="81b01207fc3c176d59c73b2bd2045c9f03853408221796994267f9cd3739689a">
        <h3>AGENT.YAML</h3>
        <details id="05263221e23246d15132edba4868ceac247548a28f15d103ee3daf37a2c17ee4">
            <summary>Bump Operator image version</summary>
            <p>change detected:&#xA;&#x9;* key &#34;$.image.tag&#34; updated from &#34;v0.41.1&#34; to &#34;v0.42.0&#34;, in file &#34;grafana/operator-values.yaml&#34;</p>
            <details>
                <summary>v0.42.0</summary>
                <pre>&#xA;Release published on the 2024-07-24 10:58:01 +0000 UTC at the url https://github.com/grafana/agent/releases/tag/v0.42.0&#xA;&#xA;This is release `v0.42.0` of Grafana Agent.&#xD;&#xA;&#xD;&#xA;### Upgrading&#xD;&#xA;&#xD;&#xA;Read the relevant upgrade guides for specific instructions on upgrading from older versions:&#xD;&#xA;&#xD;&#xA;* [Static mode upgrade guide](https://grafana.com/docs/agent/v0.42/static/upgrade-guide/)&#xD;&#xA;* [Static mode Kubernetes operator upgrade guide](https://grafana.com/docs/agent/v0.42/operator/upgrade-guide/)&#xD;&#xA;* [Flow mode upgrade guide](https://grafana.com/docs/agent/v0.42/flow/upgrade-guide/)&#xD;&#xA;&#xD;&#xA;### Changes:&#xD;&#xA;&#xD;&#xA;#### Security fixes&#xD;&#xA;&#xD;&#xA;- Fixes following vulnerabilities (@ptodev)&#xD;&#xA;  * [GHSA-87m9-rv8p-rgmg](https://github.com/open-telemetry/opentelemetry-collector/security/advisories/GHSA-c74f-6mfw-mm4v)&#xD;&#xA;  * [CVE-2024-35255](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2024-35255)&#xD;&#xA;  * [CVE-2024-6104](https://discuss.hashicorp.com/t/hcsec-2024-12-go-retryablehttp-can-leak-basic-auth-credentials-to-log-files/68027)&#xD;&#xA;  * [GHSA-mh55-gqvf-xfwm](https://github.com/advisories/GHSA-mh55-gqvf-xfwm)&#xD;&#xA;  * [CVE-2024-24790](https://avd.aquasec.com/nvd/2024/cve-2024-24790/)&#xD;&#xA;  * [CVE-2023-45288](https://avd.aquasec.com/nvd/cve-2023-45288)&#xD;&#xA;  * [CVE-2024-24788](https://avd.aquasec.com/nvd/cve-2024-24788)&#xD;&#xA;  * [CVE-2024-24789](https://avd.aquasec.com/nvd/cve-2024-24789)&#xD;&#xA;  * [CVE-2024-24791](https://avd.aquasec.com/nvd/cve-2024-24791)&#xD;&#xA;&#xD;&#xA;#### Features&#xD;&#xA;&#xD;&#xA;- A new `otelcol.exporter.debug` component for printing OTel telemetry from other `otelcol` components to the console. (@BarunKGP)&#xD;&#xA;&#xD;&#xA;#### Bugfixes&#xD;&#xA;&#xD;&#xA;- Fix an issue which caused the config to be reloaded if a config reload was triggered but the config hasn&#39;t changed.&#xD;&#xA;  The bug only affected the &#34;metrics&#34; and &#34;logs&#34; subsystems in Static mode. (@ptodev)&#xD;&#xA;&#xD;&#xA;- Fix a bug in Static mode and Flow which prevented config reloads to work if a Loki `metrics` stage is in the pipeline.&#xD;&#xA;  This resulted in a &#34;failed to unregister all metrics from previous promtail&#34; message. (@ptodev)&#xD;&#xA;&#xD;&#xA;#### Enhancements&#xD;&#xA;&#xD;&#xA;- Update to Go 1.22.5. (@ptodev)&#xD;&#xA;&#xD;&#xA;### Installation&#xD;&#xA;&#xD;&#xA;Refer to our installation guides for how to install the variants of Grafana Agent:&#xD;&#xA;&#xD;&#xA;* [Install static mode](https://grafana.com/docs/agent/v0.42/static/set-up/install/)&#xD;&#xA;* [Install the static mode Kubernetes operator](https://grafana.com/docs/agent/v0.42/operator/helm-getting-started/)&#xD;&#xA;* [Install flow mode](https://grafana.com/docs/agent/v0.42/flow/setup/install/)</pre>
            </details>
        </details>
        <details id="517bc12f2a25c6616f8e174e2d5a97751d0c2c93d844dc8a90e5e530e9f5dd8c">
            <summary>Bump Agent image version</summary>
            <p>changes detected:&#xA;&#x9;path &#34;locals.agent_version&#34; updated from &#34;0.41.1&#34; to &#34;0.42.0&#34; in file &#34;locals.tf&#34;</p>
            <details>
                <summary>v0.42.0</summary>
                <pre>&#xA;Release published on the 2024-07-24 10:58:01 +0000 UTC at the url https://github.com/grafana/agent/releases/tag/v0.42.0&#xA;&#xA;This is release `v0.42.0` of Grafana Agent.&#xD;&#xA;&#xD;&#xA;### Upgrading&#xD;&#xA;&#xD;&#xA;Read the relevant upgrade guides for specific instructions on upgrading from older versions:&#xD;&#xA;&#xD;&#xA;* [Static mode upgrade guide](https://grafana.com/docs/agent/v0.42/static/upgrade-guide/)&#xD;&#xA;* [Static mode Kubernetes operator upgrade guide](https://grafana.com/docs/agent/v0.42/operator/upgrade-guide/)&#xD;&#xA;* [Flow mode upgrade guide](https://grafana.com/docs/agent/v0.42/flow/upgrade-guide/)&#xD;&#xA;&#xD;&#xA;### Changes:&#xD;&#xA;&#xD;&#xA;#### Security fixes&#xD;&#xA;&#xD;&#xA;- Fixes following vulnerabilities (@ptodev)&#xD;&#xA;  * [GHSA-87m9-rv8p-rgmg](https://github.com/open-telemetry/opentelemetry-collector/security/advisories/GHSA-c74f-6mfw-mm4v)&#xD;&#xA;  * [CVE-2024-35255](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2024-35255)&#xD;&#xA;  * [CVE-2024-6104](https://discuss.hashicorp.com/t/hcsec-2024-12-go-retryablehttp-can-leak-basic-auth-credentials-to-log-files/68027)&#xD;&#xA;  * [GHSA-mh55-gqvf-xfwm](https://github.com/advisories/GHSA-mh55-gqvf-xfwm)&#xD;&#xA;  * [CVE-2024-24790](https://avd.aquasec.com/nvd/2024/cve-2024-24790/)&#xD;&#xA;  * [CVE-2023-45288](https://avd.aquasec.com/nvd/cve-2023-45288)&#xD;&#xA;  * [CVE-2024-24788](https://avd.aquasec.com/nvd/cve-2024-24788)&#xD;&#xA;  * [CVE-2024-24789](https://avd.aquasec.com/nvd/cve-2024-24789)&#xD;&#xA;  * [CVE-2024-24791](https://avd.aquasec.com/nvd/cve-2024-24791)&#xD;&#xA;&#xD;&#xA;#### Features&#xD;&#xA;&#xD;&#xA;- A new `otelcol.exporter.debug` component for printing OTel telemetry from other `otelcol` components to the console. (@BarunKGP)&#xD;&#xA;&#xD;&#xA;#### Bugfixes&#xD;&#xA;&#xD;&#xA;- Fix an issue which caused the config to be reloaded if a config reload was triggered but the config hasn&#39;t changed.&#xD;&#xA;  The bug only affected the &#34;metrics&#34; and &#34;logs&#34; subsystems in Static mode. (@ptodev)&#xD;&#xA;&#xD;&#xA;- Fix a bug in Static mode and Flow which prevented config reloads to work if a Loki `metrics` stage is in the pipeline.&#xD;&#xA;  This resulted in a &#34;failed to unregister all metrics from previous promtail&#34; message. (@ptodev)&#xD;&#xA;&#xD;&#xA;#### Enhancements&#xD;&#xA;&#xD;&#xA;- Update to Go 1.22.5. (@ptodev)&#xD;&#xA;&#xD;&#xA;### Installation&#xD;&#xA;&#xD;&#xA;Refer to our installation guides for how to install the variants of Grafana Agent:&#xD;&#xA;&#xD;&#xA;* [Install static mode](https://grafana.com/docs/agent/v0.42/static/set-up/install/)&#xD;&#xA;* [Install the static mode Kubernetes operator](https://grafana.com/docs/agent/v0.42/operator/helm-getting-started/)&#xD;&#xA;* [Install flow mode](https://grafana.com/docs/agent/v0.42/flow/setup/install/)</pre>
            </details>
        </details>
        <details id="7a7f09de08e3dc01c5bbf90657ecc83d5c2da9f5791f1ebe84132b95422878dc">
            <summary>run kubectl when chart values changed</summary>
            <p>ran shell command &#34;rm -rf grafana/charts ksm/charts &amp;&amp; kubectl kustomize . -o grafana-agent.yaml --enable-helm &amp;&amp; git diff --shortstat grafana-agent.yaml&#34;</p>
        </details>
        <details id="ab0ee30df2545cedb3139e6e8ff673a28e83a5be18809abc7c541d44cf4468d0">
            <summary>Bump Operator module version</summary>
            <p>changes detected:&#xA;&#x9;path &#34;locals.version&#34; updated from &#34;0.41.1&#34; to &#34;0.42.0&#34; in file &#34;locals.tf&#34;</p>
            <details>
                <summary>v0.42.0</summary>
                <pre>&#xA;Release published on the 2024-07-24 10:58:01 +0000 UTC at the url https://github.com/grafana/agent/releases/tag/v0.42.0&#xA;&#xA;This is release `v0.42.0` of Grafana Agent.&#xD;&#xA;&#xD;&#xA;### Upgrading&#xD;&#xA;&#xD;&#xA;Read the relevant upgrade guides for specific instructions on upgrading from older versions:&#xD;&#xA;&#xD;&#xA;* [Static mode upgrade guide](https://grafana.com/docs/agent/v0.42/static/upgrade-guide/)&#xD;&#xA;* [Static mode Kubernetes operator upgrade guide](https://grafana.com/docs/agent/v0.42/operator/upgrade-guide/)&#xD;&#xA;* [Flow mode upgrade guide](https://grafana.com/docs/agent/v0.42/flow/upgrade-guide/)&#xD;&#xA;&#xD;&#xA;### Changes:&#xD;&#xA;&#xD;&#xA;#### Security fixes&#xD;&#xA;&#xD;&#xA;- Fixes following vulnerabilities (@ptodev)&#xD;&#xA;  * [GHSA-87m9-rv8p-rgmg](https://github.com/open-telemetry/opentelemetry-collector/security/advisories/GHSA-c74f-6mfw-mm4v)&#xD;&#xA;  * [CVE-2024-35255](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2024-35255)&#xD;&#xA;  * [CVE-2024-6104](https://discuss.hashicorp.com/t/hcsec-2024-12-go-retryablehttp-can-leak-basic-auth-credentials-to-log-files/68027)&#xD;&#xA;  * [GHSA-mh55-gqvf-xfwm](https://github.com/advisories/GHSA-mh55-gqvf-xfwm)&#xD;&#xA;  * [CVE-2024-24790](https://avd.aquasec.com/nvd/2024/cve-2024-24790/)&#xD;&#xA;  * [CVE-2023-45288](https://avd.aquasec.com/nvd/cve-2023-45288)&#xD;&#xA;  * [CVE-2024-24788](https://avd.aquasec.com/nvd/cve-2024-24788)&#xD;&#xA;  * [CVE-2024-24789](https://avd.aquasec.com/nvd/cve-2024-24789)&#xD;&#xA;  * [CVE-2024-24791](https://avd.aquasec.com/nvd/cve-2024-24791)&#xD;&#xA;&#xD;&#xA;#### Features&#xD;&#xA;&#xD;&#xA;- A new `otelcol.exporter.debug` component for printing OTel telemetry from other `otelcol` components to the console. (@BarunKGP)&#xD;&#xA;&#xD;&#xA;#### Bugfixes&#xD;&#xA;&#xD;&#xA;- Fix an issue which caused the config to be reloaded if a config reload was triggered but the config hasn&#39;t changed.&#xD;&#xA;  The bug only affected the &#34;metrics&#34; and &#34;logs&#34; subsystems in Static mode. (@ptodev)&#xD;&#xA;&#xD;&#xA;- Fix a bug in Static mode and Flow which prevented config reloads to work if a Loki `metrics` stage is in the pipeline.&#xD;&#xA;  This resulted in a &#34;failed to unregister all metrics from previous promtail&#34; message. (@ptodev)&#xD;&#xA;&#xD;&#xA;#### Enhancements&#xD;&#xA;&#xD;&#xA;- Update to Go 1.22.5. (@ptodev)&#xD;&#xA;&#xD;&#xA;### Installation&#xD;&#xA;&#xD;&#xA;Refer to our installation guides for how to install the variants of Grafana Agent:&#xD;&#xA;&#xD;&#xA;* [Install static mode](https://grafana.com/docs/agent/v0.42/static/set-up/install/)&#xD;&#xA;* [Install the static mode Kubernetes operator](https://grafana.com/docs/agent/v0.42/operator/helm-getting-started/)&#xD;&#xA;* [Install flow mode](https://grafana.com/docs/agent/v0.42/flow/setup/install/)</pre>
            </details>
        </details>
        <a href="https://github.com/opzkit/terraform-aws-k8s-addons-grafana-agent-operator/actions/runs/10113867745">GitHub Action workflow link</a>
    </action>
</Actions>

---

<table>
  <tr>
    <td width="77">
      <img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="50" height="50">
    </td>
    <td>
      <p>
        Created automatically by <a href="https://www.updatecli.io/">Updatecli</a>
      </p>
      <details><summary>Options:</summary>
        <br />
        <p>Most of Updatecli configuration is done via <a href="https://www.updatecli.io/docs/prologue/quick-start/">its manifest(s)</a>.</p>
        <ul>
          <li>If you close this pull request, Updatecli will automatically reopen it, the next time it runs.</li>
          <li>If you close this pull request and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
        </ul>
        <p>
          Feel free to report any issues at <a href="https://github.com/updatecli/updatecli/issues">github.com/updatecli/updatecli</a>.<br />
          If you find this tool useful, do not hesitate to star <a href="https://github.com/updatecli/updatecli/stargazers">our GitHub repository</a> as a sign of appreciation, and/or to tell us directly on our <a href="https://matrix.to/#/#Updatecli_community:gitter.im">chat</a>!
        </p>
      </details>
    </td>
  </tr>
</table>

