### PR TITLE
Update Grafana Agent Image versions

### DIFF
--- a/updatecli/updatecli.d/agent.yaml
+++ b/updatecli/updatecli.d/agent.yaml
@@ -74,4 +74,4 @@ actions:
       draft: false
       labels:
       - "dependencies"
-      title: "Update Grafana Agent Operator version"
+      title: "Update Grafana Agent Image versions"


### PR DESCRIPTION



<Actions>
    <action id="81b01207fc3c176d59c73b2bd2045c9f03853408221796994267f9cd3739689a">
        <h3>AGENT.YAML</h3>
        <details id="ab0ee30df2545cedb3139e6e8ff673a28e83a5be18809abc7c541d44cf4468d0">
            <summary>Bump Operator module version</summary>
            <p>changes detected:&#xA;&#x9;path &#34;locals.version&#34; updated from &#34;0.41.1&#34; to &#34;0.42.0&#34; in file &#34;locals.tf&#34;</p>
            <details>
                <summary>v0.42.0</summary>
                <pre>&#xA;Release published on the 2024-07-24 10:58:01 +0000 UTC at the url https://github.com/grafana/agent/releases/tag/v0.42.0&#xA;&#xA;This is release `v0.42.0` of Grafana Agent.&#xD;&#xA;&#xD;&#xA;### Upgrading&#xD;&#xA;&#xD;&#xA;Read the relevant upgrade guides for specific instructions on upgrading from older versions:&#xD;&#xA;&#xD;&#xA;* [Static mode upgrade guide](https://grafana.com/docs/agent/v0.42/static/upgrade-guide/)&#xD;&#xA;* [Static mode Kubernetes operator upgrade guide](https://grafana.com/docs/agent/v0.42/operator/upgrade-guide/)&#xD;&#xA;* [Flow mode upgrade guide](https://grafana.com/docs/agent/v0.42/flow/upgrade-guide/)&#xD;&#xA;&#xD;&#xA;### Changes:&#xD;&#xA;&#xD;&#xA;#### Security fixes&#xD;&#xA;&#xD;&#xA;- Fixes following vulnerabilities (@ptodev)&#xD;&#xA;  * [GHSA-87m9-rv8p-rgmg](https://github.com/open-telemetry/opentelemetry-collector/security/advisories/GHSA-c74f-6mfw-mm4v)&#xD;&#xA;  * [CVE-2024-35255](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2024-35255)&#xD;&#xA;  * [CVE-2024-6104](https://discuss.hashicorp.com/t/hcsec-2024-12-go-retryablehttp-can-leak-basic-auth-credentials-to-log-files/68027)&#xD;&#xA;  * [GHSA-mh55-gqvf-xfwm](https://github.com/advisories/GHSA-mh55-gqvf-xfwm)&#xD;&#xA;  * [CVE-2024-24790](https://avd.aquasec.com/nvd/2024/cve-2024-24790/)&#xD;&#xA;  * [CVE-2023-45288](https://avd.aquasec.com/nvd/cve-2023-45288)&#xD;&#xA;  * [CVE-2024-24788](https://avd.aquasec.com/nvd/cve-2024-24788)&#xD;&#xA;  * [CVE-2024-24789](https://avd.aquasec.com/nvd/cve-2024-24789)&#xD;&#xA;  * [CVE-2024-24791](https://avd.aquasec.com/nvd/cve-2024-24791)&#xD;&#xA;&#xD;&#xA;#### Features&#xD;&#xA;&#xD;&#xA;- A new `otelcol.exporter.debug` component for printing OTel telemetry from other `otelcol` components to the console. (@BarunKGP)&#xD;&#xA;&#xD;&#xA;#### Bugfixes&#xD;&#xA;&#xD;&#xA;- Fix an issue which caused the config to be reloaded if a config reload was triggered but the config hasn&#39;t changed.&#xD;&#xA;  The bug only affected the &#34;metrics&#34; and &#34;logs&#34; subsystems in Static mode. (@ptodev)&#xD;&#xA;&#xD;&#xA;- Fix a bug in Static mode and Flow which prevented config reloads to work if a Loki `metrics` stage is in the pipeline.&#xD;&#xA;  This resulted in a &#34;failed to unregister all metrics from previous promtail&#34; message. (@ptodev)&#xD;&#xA;&#xD;&#xA;#### Enhancements&#xD;&#xA;&#xD;&#xA;- Update to Go 1.22.5. (@ptodev)&#xD;&#xA;&#xD;&#xA;### Installation&#xD;&#xA;&#xD;&#xA;Refer to our installation guides for how to install the variants of Grafana Agent:&#xD;&#xA;&#xD;&#xA;* [Install static mode](https://grafana.com/docs/agent/v0.42/static/set-up/install/)&#xD;&#xA;* [Install the static mode Kubernetes operator](https://grafana.com/docs/agent/v0.42/operator/helm-getting-started/)&#xD;&#xA;* [Install flow mode](https://grafana.com/docs/agent/v0.42/flow/setup/install/)</pre>
            </details>
        </details>
        <details id="7a7f09de08e3dc01c5bbf90657ecc83d5c2da9f5791f1ebe84132b95422878dc">
            <summary>run kubectl when chart values changed</summary>
            <p>ran shell command &#34;rm -rf grafana/charts ksm/charts &amp;&amp; kubectl kustomize . -o grafana-agent.yaml --enable-helm &amp;&amp; git diff --shortstat grafana-agent.yaml&#34;</p>
        </details>
        <details id="517bc12f2a25c6616f8e174e2d5a97751d0c2c93d844dc8a90e5e530e9f5dd8c">
            <summary>Bump Agent image version</summary>
            <p>changes detected:&#xA;&#x9;path &#34;locals.agent_version&#34; updated from &#34;0.41.1&#34; to &#34;0.42.0&#34; in file &#34;locals.tf&#34;</p>
            <details>
                <summary>v0.42.0</summary>
                <pre>&#xA;Release published on the 2024-07-24 10:58:01 +0000 UTC at the url https://github.com/grafana/agent/releases/tag/v0.42.0&#xA;&#xA;This is release `v0.42.0` of Grafana Agent.&#xD;&#xA;&#xD;&#xA;### Upgrading&#xD;&#xA;&#xD;&#xA;Read the relevant upgrade guides for specific instructions on upgrading from older versions:&#xD;&#xA;&#xD;&#xA;* [Static mode upgrade guide](https://grafana.com/docs/agent/v0.42/static/upgrade-guide/)&#xD;&#xA;* [Static mode Kubernetes operator upgrade guide](https://grafana.com/docs/agent/v0.42/operator/upgrade-guide/)&#xD;&#xA;* [Flow mode upgrade guide](https://grafana.com/docs/agent/v0.42/flow/upgrade-guide/)&#xD;&#xA;&#xD;&#xA;### Changes:&#xD;&#xA;&#xD;&#xA;#### Security fixes&#xD;&#xA;&#xD;&#xA;- Fixes following vulnerabilities (@ptodev)&#xD;&#xA;  * [GHSA-87m9-rv8p-rgmg](https://github.com/open-telemetry/opentelemetry-collector/security/advisories/GHSA-c74f-6mfw-mm4v)&#xD;&#xA;  * [CVE-2024-35255](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2024-35255)&#xD;&#xA;  * [CVE-2024-6104](https://discuss.hashicorp.com/t/hcsec-2024-12-go-retryablehttp-can-leak-basic-auth-credentials-to-log-files/68027)&#xD;&#xA;  * [GHSA-mh55-gqvf-xfwm](https://github.com/advisories/GHSA-mh55-gqvf-xfwm)&#xD;&#xA;  * [CVE-2024-24790](https://avd.aquasec.com/nvd/2024/cve-2024-24790/)&#xD;&#xA;  * [CVE-2023-45288](https://avd.aquasec.com/nvd/cve-2023-45288)&#xD;&#xA;  * [CVE-2024-24788](https://avd.aquasec.com/nvd/cve-2024-24788)&#xD;&#xA;  * [CVE-2024-24789](https://avd.aquasec.com/nvd/cve-2024-24789)&#xD;&#xA;  * [CVE-2024-24791](https://avd.aquasec.com/nvd/cve-2024-24791)&#xD;&#xA;&#xD;&#xA;#### Features&#xD;&#xA;&#xD;&#xA;- A new `otelcol.exporter.debug` component for printing OTel telemetry from other `otelcol` components to the console. (@BarunKGP)&#xD;&#xA;&#xD;&#xA;#### Bugfixes&#xD;&#xA;&#xD;&#xA;- Fix an issue which caused the config to be reloaded if a config reload was triggered but the config hasn&#39;t changed.&#xD;&#xA;  The bug only affected the &#34;metrics&#34; and &#34;logs&#34; subsystems in Static mode. (@ptodev)&#xD;&#xA;&#xD;&#xA;- Fix a bug in Static mode and Flow which prevented config reloads to work if a Loki `metrics` stage is in the pipeline.&#xD;&#xA;  This resulted in a &#34;failed to unregister all metrics from previous promtail&#34; message. (@ptodev)&#xD;&#xA;&#xD;&#xA;#### Enhancements&#xD;&#xA;&#xD;&#xA;- Update to Go 1.22.5. (@ptodev)&#xD;&#xA;&#xD;&#xA;### Installation&#xD;&#xA;&#xD;&#xA;Refer to our installation guides for how to install the variants of Grafana Agent:&#xD;&#xA;&#xD;&#xA;* [Install static mode](https://grafana.com/docs/agent/v0.42/static/set-up/install/)&#xD;&#xA;* [Install the static mode Kubernetes operator](https://grafana.com/docs/agent/v0.42/operator/helm-getting-started/)&#xD;&#xA;* [Install flow mode](https://grafana.com/docs/agent/v0.42/flow/setup/install/)</pre>
            </details>
        </details>
        <details id="05263221e23246d15132edba4868ceac247548a28f15d103ee3daf37a2c17ee4">
            <summary>Bump Operator image version</summary>
            <p>change detected:&#xA;&#x9;* key &#34;$.image.tag&#34; updated from &#34;v0.41.1&#34; to &#34;v0.42.0&#34;, in file &#34;grafana/operator-values.yaml&#34;</p>
            <details>
                <summary>v0.42.0</summary>
                <pre>&#xA;Release published on the 2024-07-24 10:58:01 +0000 UTC at the url https://github.com/grafana/agent/releases/tag/v0.42.0&#xA;&#xA;This is release `v0.42.0` of Grafana Agent.&#xD;&#xA;&#xD;&#xA;### Upgrading&#xD;&#xA;&#xD;&#xA;Read the relevant upgrade guides for specific instructions on upgrading from older versions:&#xD;&#xA;&#xD;&#xA;* [Static mode upgrade guide](https://grafana.com/docs/agent/v0.42/static/upgrade-guide/)&#xD;&#xA;* [Static mode Kubernetes operator upgrade guide](https://grafana.com/docs/agent/v0.42/operator/upgrade-guide/)&#xD;&#xA;* [Flow mode upgrade guide](https://grafana.com/docs/agent/v0.42/flow/upgrade-guide/)&#xD;&#xA;&#xD;&#xA;### Changes:&#xD;&#xA;&#xD;&#xA;#### Security fixes&#xD;&#xA;&#xD;&#xA;- Fixes following vulnerabilities (@ptodev)&#xD;&#xA;  * [GHSA-87m9-rv8p-rgmg](https://github.com/open-telemetry/opentelemetry-collector/security/advisories/GHSA-c74f-6mfw-mm4v)&#xD;&#xA;  * [CVE-2024-35255](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2024-35255)&#xD;&#xA;  * [CVE-2024-6104](https://discuss.hashicorp.com/t/hcsec-2024-12-go-retryablehttp-can-leak-basic-auth-credentials-to-log-files/68027)&#xD;&#xA;  * [GHSA-mh55-gqvf-xfwm](https://github.com/advisories/GHSA-mh55-gqvf-xfwm)&#xD;&#xA;  * [CVE-2024-24790](https://avd.aquasec.com/nvd/2024/cve-2024-24790/)&#xD;&#xA;  * [CVE-2023-45288](https://avd.aquasec.com/nvd/cve-2023-45288)&#xD;&#xA;  * [CVE-2024-24788](https://avd.aquasec.com/nvd/cve-2024-24788)&#xD;&#xA;  * [CVE-2024-24789](https://avd.aquasec.com/nvd/cve-2024-24789)&#xD;&#xA;  * [CVE-2024-24791](https://avd.aquasec.com/nvd/cve-2024-24791)&#xD;&#xA;&#xD;&#xA;#### Features&#xD;&#xA;&#xD;&#xA;- A new `otelcol.exporter.debug` component for printing OTel telemetry from other `otelcol` components to the console. (@BarunKGP)&#xD;&#xA;&#xD;&#xA;#### Bugfixes&#xD;&#xA;&#xD;&#xA;- Fix an issue which caused the config to be reloaded if a config reload was triggered but the config hasn&#39;t changed.&#xD;&#xA;  The bug only affected the &#34;metrics&#34; and &#34;logs&#34; subsystems in Static mode. (@ptodev)&#xD;&#xA;&#xD;&#xA;- Fix a bug in Static mode and Flow which prevented config reloads to work if a Loki `metrics` stage is in the pipeline.&#xD;&#xA;  This resulted in a &#34;failed to unregister all metrics from previous promtail&#34; message. (@ptodev)&#xD;&#xA;&#xD;&#xA;#### Enhancements&#xD;&#xA;&#xD;&#xA;- Update to Go 1.22.5. (@ptodev)&#xD;&#xA;&#xD;&#xA;### Installation&#xD;&#xA;&#xD;&#xA;Refer to our installation guides for how to install the variants of Grafana Agent:&#xD;&#xA;&#xD;&#xA;* [Install static mode](https://grafana.com/docs/agent/v0.42/static/set-up/install/)&#xD;&#xA;* [Install the static mode Kubernetes operator](https://grafana.com/docs/agent/v0.42/operator/helm-getting-started/)&#xD;&#xA;* [Install flow mode](https://grafana.com/docs/agent/v0.42/flow/setup/install/)</pre>
            </details>
        </details>
        <a href="https://github.com/opzkit/terraform-aws-k8s-addons-grafana-agent-operator/actions/runs/10113975391">GitHub Action workflow link</a>
    </action>
</Actions>

---

<table>
  <tr>
    <td width="77">
      <img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="50" height="50">
    </td>
    <td>
      <p>
        Created automatically by <a href="https://www.updatecli.io/">Updatecli</a>
      </p>
      <details><summary>Options:</summary>
        <br />
        <p>Most of Updatecli configuration is done via <a href="https://www.updatecli.io/docs/prologue/quick-start/">its manifest(s)</a>.</p>
        <ul>
          <li>If you close this pull request, Updatecli will automatically reopen it, the next time it runs.</li>
          <li>If you close this pull request and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
        </ul>
        <p>
          Feel free to report any issues at <a href="https://github.com/updatecli/updatecli/issues">github.com/updatecli/updatecli</a>.<br />
          If you find this tool useful, do not hesitate to star <a href="https://github.com/updatecli/updatecli/stargazers">our GitHub repository</a> as a sign of appreciation, and/or to tell us directly on our <a href="https://matrix.to/#/#Updatecli_community:gitter.im">chat</a>!
        </p>
      </details>
    </td>
  </tr>
</table>

