### PR TITLE
chore(deps): update Grafana Agent Operator version

### DIFF
--- a/grafana-agent.yaml
+++ b/grafana-agent.yaml
@@ -6952,8 +6952,8 @@ metadata:
     app.kubernetes.io/instance: grafana-agent-operator
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: grafana-agent-operator
-    app.kubernetes.io/version: 0.43.2
-    helm.sh/chart: grafana-agent-operator-0.4.3
+    app.kubernetes.io/version: 0.43.3
+    helm.sh/chart: grafana-agent-operator-0.4.4
   name: grafana-agent-operator
   namespace: grafana-agent
 ---
@@ -6980,8 +6980,8 @@ metadata:
     app.kubernetes.io/instance: grafana-agent-operator
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: grafana-agent-operator
-    app.kubernetes.io/version: 0.43.2
-    helm.sh/chart: grafana-agent-operator-0.4.3
+    app.kubernetes.io/version: 0.43.3
+    helm.sh/chart: grafana-agent-operator-0.4.4
   name: grafana-agent-operator
 rules:
 - apiGroups:
@@ -7291,8 +7291,8 @@ metadata:
     app.kubernetes.io/instance: grafana-agent-operator
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: grafana-agent-operator
-    app.kubernetes.io/version: 0.43.2
-    helm.sh/chart: grafana-agent-operator-0.4.3
+    app.kubernetes.io/version: 0.43.3
+    helm.sh/chart: grafana-agent-operator-0.4.4
   name: grafana-agent-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -7358,8 +7358,8 @@ metadata:
     app.kubernetes.io/instance: grafana-agent-operator
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: grafana-agent-operator
-    app.kubernetes.io/version: 0.43.2
-    helm.sh/chart: grafana-agent-operator-0.4.3
+    app.kubernetes.io/version: 0.43.3
+    helm.sh/chart: grafana-agent-operator-0.4.4
   name: grafana-agent-operator
   namespace: grafana-agent
 spec:
@@ -7377,7 +7377,7 @@ spec:
       containers:
       - args:
         - --kubelet-service=default/kubelet
-        image: docker.io/grafana/agent-operator:v0.43.2
+        image: docker.io/grafana/agent-operator:v0.43.3
         imagePullPolicy: IfNotPresent
         name: grafana-agent-operator
         resources:

--- a/grafana/kustomization.yaml
+++ b/grafana/kustomization.yaml
@@ -7,7 +7,7 @@ helmCharts:
 - name: grafana-agent-operator
   namespace: grafana-agent
   repo: https://grafana.github.io/helm-charts
-  version: '0.4.3'
+  version: '0.4.4'
   releaseName: grafana-agent-operator
   includeCRDs: true
   valuesFile: operator-values.yaml

--- a/grafana/operator-values.yaml
+++ b/grafana/operator-values.yaml
@@ -1,5 +1,5 @@
 image:
-  tag: v0.43.2
+  tag: v0.43.3
 resources:
   requests:
     memory: 30Mi

--- a/locals.tf
+++ b/locals.tf
@@ -1,6 +1,6 @@
 locals {
   version       = "0.43.2"
-  agent_version = "0.43.2"
+  agent_version = "0.43.3"
   yaml = templatefile("${path.module}/custom-resources.yaml.tmpl", {
     cluster_name         = var.cluster_name
     external_labels      = merge({ cluster = var.cluster_name }, var.external_labels)

--- a/locals.tf
+++ b/locals.tf
@@ -1,5 +1,5 @@
 locals {
-  version       = "0.43.2"
+  version       = "0.43.3"
   agent_version = "0.43.3"
   yaml = templatefile("${path.module}/custom-resources.yaml.tmpl", {
     cluster_name         = var.cluster_name


### PR DESCRIPTION



<Actions>
    <action id="6cf709b248763db9b34b0d983b59426500ef9288722dbc447ee0de5ef7fa5f2f">
        <h3>GRAFANA.YAML</h3>
        <details id="7a7f09de08e3dc01c5bbf90657ecc83d5c2da9f5791f1ebe84132b95422878dc">
            <summary>run kubectl when chart changed</summary>
            <p>ran shell command &#34;rm -rf grafana/charts ksm/charts &amp;&amp; kubectl kustomize . -o grafana-agent.yaml --enable-helm&#34;</p>
        </details>
        <details id="4113bf23ce9d46c0e662e1ab43b1531da491f9885a1e3775df30a2f358759c0f">
            <summary>bump chart version</summary>
            <p>change detected:&#xA;&#x9;* key &#34;$.helmCharts[0].version&#34; updated from &#34;&#39;0.4.3&#39;&#34; to &#34;&#39;0.4.4&#39;&#34;, in file &#34;grafana/kustomization.yaml&#34;</p>
            <details>
                <summary>0.4.4</summary>
                <pre>&#xA;Remark: We couldn&#39;t identify a way to automatically retrieve changelog information.&#xA;Please use following information to take informed decision&#xA;&#xA;Helm Chart: grafana-agent-operator&#xA;A Helm chart for Grafana Agent Operator&#xA;Project Home: https://grafana.com/docs/agent/v0.43/&#xA;&#xA;Version created on the 2024-09-26 16:15:50.408782902 &amp;#43;0000 UTC&#xA;&#xA;Sources:&#xA;&#xA;* https://github.com/grafana/agent/tree/v0.43.3/static/operator&#xA;&#xA;&#xA;&#xA;URL:&#xA;&#xA;* https://github.com/grafana/helm-charts/releases/download/grafana-agent-operator-0.4.4/grafana-agent-operator-0.4.4.tgz&#xA;&#xA;&#xA;</pre>
            </details>
        </details>
        <details id="517bc12f2a25c6616f8e174e2d5a97751d0c2c93d844dc8a90e5e530e9f5dd8c">
            <summary>Bump Agent image version</summary>
            <p>changes detected:&#xA;&#x9;path &#34;locals.agent_version&#34; updated from &#34;0.43.2&#34; to &#34;0.43.3&#34; in file &#34;locals.tf&#34;</p>
            <details>
                <summary>v0.43.3</summary>
                <pre>&#xA;Release published on the 2024-09-26 16:01:25 +0000 UTC at the url https://github.com/grafana/agent/releases/tag/v0.43.3&#xA;&#xA;This is release `v0.43.3` of Grafana Agent.&#xD;&#xA;&#xD;&#xA;### Upgrading&#xD;&#xA;&#xD;&#xA;Read the relevant upgrade guides for specific instructions on upgrading from older versions:&#xD;&#xA;&#xD;&#xA;* [Static mode upgrade guide](https://grafana.com/docs/agent/v0.43/static/upgrade-guide/)&#xD;&#xA;* [Static mode Kubernetes operator upgrade guide](https://grafana.com/docs/agent/v0.43/operator/upgrade-guide/)&#xD;&#xA;* [Flow mode upgrade guide](https://grafana.com/docs/agent/v0.43/flow/upgrade-guide/)&#xD;&#xA;&#xD;&#xA;### Notable changes:&#xD;&#xA;&#xD;&#xA;#### Bugfixes&#xD;&#xA;&#xD;&#xA;- Windows installer: Don&#39;t quote Alloy&#39;s binary path in the Windows Registry. (@jkroepke)&#xD;&#xA;&#xD;&#xA;### Installation&#xD;&#xA;&#xD;&#xA;Refer to our installation guides for how to install the variants of Grafana Agent:&#xD;&#xA;&#xD;&#xA;* [Install static mode](https://grafana.com/docs/agent/v0.43/static/set-up/install/)&#xD;&#xA;* [Install the static mode Kubernetes operator](https://grafana.com/docs/agent/v0.43/operator/helm-getting-started/)&#xD;&#xA;* [Install flow mode](https://grafana.com/docs/agent/v0.43/flow/setup/install/)</pre>
            </details>
        </details>
        <details id="05263221e23246d15132edba4868ceac247548a28f15d103ee3daf37a2c17ee4">
            <summary>Bump Operator image version</summary>
            <p>change detected:&#xA;&#x9;* key &#34;$.image.tag&#34; updated from &#34;v0.43.2&#34; to &#34;v0.43.3&#34;, in file &#34;grafana/operator-values.yaml&#34;</p>
            <details>
                <summary>v0.43.3</summary>
                <pre>&#xA;Release published on the 2024-09-26 16:01:25 +0000 UTC at the url https://github.com/grafana/agent/releases/tag/v0.43.3&#xA;&#xA;This is release `v0.43.3` of Grafana Agent.&#xD;&#xA;&#xD;&#xA;### Upgrading&#xD;&#xA;&#xD;&#xA;Read the relevant upgrade guides for specific instructions on upgrading from older versions:&#xD;&#xA;&#xD;&#xA;* [Static mode upgrade guide](https://grafana.com/docs/agent/v0.43/static/upgrade-guide/)&#xD;&#xA;* [Static mode Kubernetes operator upgrade guide](https://grafana.com/docs/agent/v0.43/operator/upgrade-guide/)&#xD;&#xA;* [Flow mode upgrade guide](https://grafana.com/docs/agent/v0.43/flow/upgrade-guide/)&#xD;&#xA;&#xD;&#xA;### Notable changes:&#xD;&#xA;&#xD;&#xA;#### Bugfixes&#xD;&#xA;&#xD;&#xA;- Windows installer: Don&#39;t quote Alloy&#39;s binary path in the Windows Registry. (@jkroepke)&#xD;&#xA;&#xD;&#xA;### Installation&#xD;&#xA;&#xD;&#xA;Refer to our installation guides for how to install the variants of Grafana Agent:&#xD;&#xA;&#xD;&#xA;* [Install static mode](https://grafana.com/docs/agent/v0.43/static/set-up/install/)&#xD;&#xA;* [Install the static mode Kubernetes operator](https://grafana.com/docs/agent/v0.43/operator/helm-getting-started/)&#xD;&#xA;* [Install flow mode](https://grafana.com/docs/agent/v0.43/flow/setup/install/)</pre>
            </details>
        </details>
        <details id="ab0ee30df2545cedb3139e6e8ff673a28e83a5be18809abc7c541d44cf4468d0">
            <summary>Bump Operator module version</summary>
            <p>changes detected:&#xA;&#x9;path &#34;locals.version&#34; updated from &#34;0.43.2&#34; to &#34;0.43.3&#34; in file &#34;locals.tf&#34;</p>
            <details>
                <summary>v0.43.3</summary>
                <pre>&#xA;Release published on the 2024-09-26 16:01:25 +0000 UTC at the url https://github.com/grafana/agent/releases/tag/v0.43.3&#xA;&#xA;This is release `v0.43.3` of Grafana Agent.&#xD;&#xA;&#xD;&#xA;### Upgrading&#xD;&#xA;&#xD;&#xA;Read the relevant upgrade guides for specific instructions on upgrading from older versions:&#xD;&#xA;&#xD;&#xA;* [Static mode upgrade guide](https://grafana.com/docs/agent/v0.43/static/upgrade-guide/)&#xD;&#xA;* [Static mode Kubernetes operator upgrade guide](https://grafana.com/docs/agent/v0.43/operator/upgrade-guide/)&#xD;&#xA;* [Flow mode upgrade guide](https://grafana.com/docs/agent/v0.43/flow/upgrade-guide/)&#xD;&#xA;&#xD;&#xA;### Notable changes:&#xD;&#xA;&#xD;&#xA;#### Bugfixes&#xD;&#xA;&#xD;&#xA;- Windows installer: Don&#39;t quote Alloy&#39;s binary path in the Windows Registry. (@jkroepke)&#xD;&#xA;&#xD;&#xA;### Installation&#xD;&#xA;&#xD;&#xA;Refer to our installation guides for how to install the variants of Grafana Agent:&#xD;&#xA;&#xD;&#xA;* [Install static mode](https://grafana.com/docs/agent/v0.43/static/set-up/install/)&#xD;&#xA;* [Install the static mode Kubernetes operator](https://grafana.com/docs/agent/v0.43/operator/helm-getting-started/)&#xD;&#xA;* [Install flow mode](https://grafana.com/docs/agent/v0.43/flow/setup/install/)</pre>
            </details>
        </details>
        <a href="https://github.com/opzkit/terraform-aws-k8s-addons-grafana-agent-operator/actions/runs/11062685271">GitHub Action workflow link</a>
    </action>
</Actions>

---

<table>
  <tr>
    <td width="77">
      <img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="50" height="50">
    </td>
    <td>
      <p>
        Created automatically by <a href="https://www.updatecli.io/">Updatecli</a>
      </p>
      <details><summary>Options:</summary>
        <br />
        <p>Most of Updatecli configuration is done via <a href="https://www.updatecli.io/docs/prologue/quick-start/">its manifest(s)</a>.</p>
        <ul>
          <li>If you close this pull request, Updatecli will automatically reopen it, the next time it runs.</li>
          <li>If you close this pull request and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
        </ul>
        <p>
          Feel free to report any issues at <a href="https://github.com/updatecli/updatecli/issues">github.com/updatecli/updatecli</a>.<br />
          If you find this tool useful, do not hesitate to star <a href="https://github.com/updatecli/updatecli/stargazers">our GitHub repository</a> as a sign of appreciation, and/or to tell us directly on our <a href="https://matrix.to/#/#Updatecli_community:gitter.im">chat</a>!
        </p>
      </details>
    </td>
  </tr>
</table>

