### PR TITLE
chore(deps): update Grafana Agent Operator version

### DIFF
--- a/grafana-agent.yaml
+++ b/grafana-agent.yaml
@@ -6968,7 +6968,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/version: 2.14.0
-    helm.sh/chart: kube-state-metrics-5.28.0
+    helm.sh/chart: kube-state-metrics-5.28.1
   name: ksm-kube-state-metrics
   namespace: kube-system
 ---
@@ -7079,7 +7079,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/version: 2.14.0
-    helm.sh/chart: kube-state-metrics-5.28.0
+    helm.sh/chart: kube-state-metrics-5.28.1
   name: ksm-kube-state-metrics
 rules:
 - apiGroups:
@@ -7313,7 +7313,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/version: 2.14.0
-    helm.sh/chart: kube-state-metrics-5.28.0
+    helm.sh/chart: kube-state-metrics-5.28.1
   name: ksm-kube-state-metrics
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -7336,7 +7336,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/version: 2.14.0
-    helm.sh/chart: kube-state-metrics-5.28.0
+    helm.sh/chart: kube-state-metrics-5.28.1
   name: ksm-kube-state-metrics
   namespace: kube-system
 spec:
@@ -7377,7 +7377,7 @@ spec:
       containers:
       - args:
         - --kubelet-service=default/kubelet
-        image: docker.io/grafana/agent-operator:v0.43.4
+        image: docker.io/grafana/agent-operator:v0.44.2
         imagePullPolicy: IfNotPresent
         name: grafana-agent-operator
         resources:
@@ -7396,7 +7396,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: kube-state-metrics
     app.kubernetes.io/version: 2.14.0
-    helm.sh/chart: kube-state-metrics-5.28.0
+    helm.sh/chart: kube-state-metrics-5.28.1
   name: ksm-kube-state-metrics
   namespace: kube-system
 spec:
@@ -7417,7 +7417,7 @@ spec:
         app.kubernetes.io/name: kube-state-metrics
         app.kubernetes.io/part-of: kube-state-metrics
         app.kubernetes.io/version: 2.14.0
-        helm.sh/chart: kube-state-metrics-5.28.0
+        helm.sh/chart: kube-state-metrics-5.28.1
     spec:
       automountServiceAccountToken: true
       containers:

--- a/grafana/operator-values.yaml
+++ b/grafana/operator-values.yaml
@@ -1,5 +1,5 @@
 image:
-  tag: v0.43.4
+  tag: v0.44.2
 resources:
   requests:
     memory: 30Mi

--- a/ksm/kustomization.yaml
+++ b/ksm/kustomization.yaml
@@ -4,7 +4,7 @@ helmCharts:
 - name: kube-state-metrics
   namespace: kube-system
   repo: https://prometheus-community.github.io/helm-charts
-  version: '5.28.0'
+  version: '5.28.1'
   releaseName: ksm
   includeCRDs: true
   valuesFile: ksm-values.yaml

--- a/locals.tf
+++ b/locals.tf
@@ -1,6 +1,6 @@
 locals {
   version       = "0.44.2"
-  agent_version = "0.43.4"
+  agent_version = "0.44.2"
   yaml = templatefile("${path.module}/custom-resources.yaml.tmpl", {
     cluster_name         = var.cluster_name
     external_labels      = merge({ cluster = var.cluster_name }, var.external_labels)

--- a/locals.tf
+++ b/locals.tf
@@ -1,5 +1,5 @@
 locals {
-  version       = "0.43.4"
+  version       = "0.44.2"
   agent_version = "0.43.4"
   yaml = templatefile("${path.module}/custom-resources.yaml.tmpl", {
     cluster_name         = var.cluster_name


### PR DESCRIPTION



<Actions>
    <action id="6cf709b248763db9b34b0d983b59426500ef9288722dbc447ee0de5ef7fa5f2f">
        <h3>GRAFANA.YAML</h3>
        <details id="7104055ac2f98352f83cc97d5337987664a50702ea0db22a019136047f6aacca">
            <summary>bump chart version</summary>
            <p>change detected:&#xA;&#x9;* key &#34;$.helmCharts[0].version&#34; updated from &#34;&#39;5.28.0&#39;&#34; to &#34;&#39;5.28.1&#39;&#34;, in file &#34;ksm/kustomization.yaml&#34;</p>
            <details>
                <summary>5.28.1</summary>
                <pre>&#xA;Remark: We couldn&#39;t identify a way to automatically retrieve changelog information.&#xA;Please use following information to take informed decision&#xA;&#xA;Helm Chart: kube-state-metrics&#xA;Install kube-state-metrics to generate and expose cluster-level metrics&#xA;Project Home: https://github.com/kubernetes/kube-state-metrics/&#xA;&#xA;Version created on the 2025-01-29 18:45:17.41271504 &amp;#43;0000 UTC&#xA;&#xA;Sources:&#xA;&#xA;* https://github.com/kubernetes/kube-state-metrics/&#xA;&#xA;&#xA;&#xA;URL:&#xA;&#xA;* https://github.com/prometheus-community/helm-charts/releases/download/kube-state-metrics-5.28.1/kube-state-metrics-5.28.1.tgz&#xA;&#xA;&#xA;</pre>
            </details>
        </details>
        <details id="517bc12f2a25c6616f8e174e2d5a97751d0c2c93d844dc8a90e5e530e9f5dd8c">
            <summary>Bump Agent image version</summary>
            <p>changes detected:&#xA;&#x9;path &#34;locals.agent_version&#34; updated from &#34;0.43.4&#34; to &#34;0.44.2&#34; in file &#34;locals.tf&#34;</p>
            <details>
                <summary>v0.44.2</summary>
                <pre>&#xA;Release published on the 2025-01-29 17:15:37 +0000 UTC at the url https://github.com/grafana/agent/releases/tag/v0.44.2&#xA;&#xA;This is release `v0.44.2` of Grafana Agent.&#xD;&#xA;&#xD;&#xA;### Upgrading&#xD;&#xA;&#xD;&#xA;Read the relevant upgrade guides for specific instructions on upgrading from older versions:&#xD;&#xA;&#xD;&#xA;* [Static mode upgrade guide](https://grafana.com/docs/agent/v0.44/static/upgrade-guide/)&#xD;&#xA;* [Static mode Kubernetes operator upgrade guide](https://grafana.com/docs/agent/v0.44/operator/upgrade-guide/)&#xD;&#xA;* [Flow mode upgrade guide](https://grafana.com/docs/agent/v0.44/flow/upgrade-guide/)&#xD;&#xA;&#xD;&#xA;### Changes:&#xD;&#xA;&#xD;&#xA;#### Bugfixes&#xD;&#xA;&#xD;&#xA;- `loki.source.podlogs`: Fixed a bug which prevented clustering from working and caused duplicate logs to be sent.&#xD;&#xA;  The bug only happened when no `selector` or `namespace_selector` blocks were specified in the Agent configuration. (@ptodev)&#xD;&#xA;&#xD;&#xA;- `pyroscope.scrape` no longer tries to scrape endpoints which are not active targets anymore. (@wildum @mattdurham @dehaansa @ptodev)&#xD;&#xA;&#xD;&#xA;#### Enhancements&#xD;&#xA;&#xD;&#xA;- Upgrade `github.com/goccy/go-json` to v0.10.4, which reduces the memory consumption of an Agent instance by 20MB.&#xD;&#xA;  If Agent is running certain otelcol components, this reduction will not apply. (@ptodev)&#xD;&#xA;  &#xD;&#xA;#### Other changes&#xD;&#xA;&#xD;&#xA;- Remove setcap for `cap_net_bind_service` to allow Agent to run in restricted environments.&#xD;&#xA;  Modern container runtimes allow binding to unprivileged ports as non-root. (@ptodev)&#xD;&#xA;&#xD;&#xA;- Update to go 1.22.11 (@wildum)&#xD;&#xA;&#xD;&#xA;### Installation&#xD;&#xA;&#xD;&#xA;Note that Grafana Agent has been deprecated and is in Long-Term Support (LTS) through October 31, 2025. Grafana Agent will reach an End-of-Life (EOL) on November 1, 2025. Read more about why we recommend migrating to [Grafana Alloy](https://grafana.com/blog/2024/04/09/grafana-alloy-opentelemetry-collector-with-prometheus-pipelines/).&#xD;&#xA;&#xD;&#xA;Refer to our installation guides for how to install the variants of Grafana Agent:&#xD;&#xA;&#xD;&#xA;* [Install static mode](https://grafana.com/docs/agent/v0.44/static/set-up/install/)&#xD;&#xA;* [Install the static mode Kubernetes operator](https://grafana.com/docs/agent/v0.44/operator/helm-getting-started/)&#xD;&#xA;* [Install flow mode](https://grafana.com/docs/agent/v0.44/flow/setup/install/)</pre>
            </details>
        </details>
        <details id="05263221e23246d15132edba4868ceac247548a28f15d103ee3daf37a2c17ee4">
            <summary>Bump Operator image version</summary>
            <p>change detected:&#xA;&#x9;* key &#34;$.image.tag&#34; updated from &#34;v0.43.4&#34; to &#34;v0.44.2&#34;, in file &#34;grafana/operator-values.yaml&#34;</p>
            <details>
                <summary>v0.44.2</summary>
                <pre>&#xA;Release published on the 2025-01-29 17:15:37 +0000 UTC at the url https://github.com/grafana/agent/releases/tag/v0.44.2&#xA;&#xA;This is release `v0.44.2` of Grafana Agent.&#xD;&#xA;&#xD;&#xA;### Upgrading&#xD;&#xA;&#xD;&#xA;Read the relevant upgrade guides for specific instructions on upgrading from older versions:&#xD;&#xA;&#xD;&#xA;* [Static mode upgrade guide](https://grafana.com/docs/agent/v0.44/static/upgrade-guide/)&#xD;&#xA;* [Static mode Kubernetes operator upgrade guide](https://grafana.com/docs/agent/v0.44/operator/upgrade-guide/)&#xD;&#xA;* [Flow mode upgrade guide](https://grafana.com/docs/agent/v0.44/flow/upgrade-guide/)&#xD;&#xA;&#xD;&#xA;### Changes:&#xD;&#xA;&#xD;&#xA;#### Bugfixes&#xD;&#xA;&#xD;&#xA;- `loki.source.podlogs`: Fixed a bug which prevented clustering from working and caused duplicate logs to be sent.&#xD;&#xA;  The bug only happened when no `selector` or `namespace_selector` blocks were specified in the Agent configuration. (@ptodev)&#xD;&#xA;&#xD;&#xA;- `pyroscope.scrape` no longer tries to scrape endpoints which are not active targets anymore. (@wildum @mattdurham @dehaansa @ptodev)&#xD;&#xA;&#xD;&#xA;#### Enhancements&#xD;&#xA;&#xD;&#xA;- Upgrade `github.com/goccy/go-json` to v0.10.4, which reduces the memory consumption of an Agent instance by 20MB.&#xD;&#xA;  If Agent is running certain otelcol components, this reduction will not apply. (@ptodev)&#xD;&#xA;  &#xD;&#xA;#### Other changes&#xD;&#xA;&#xD;&#xA;- Remove setcap for `cap_net_bind_service` to allow Agent to run in restricted environments.&#xD;&#xA;  Modern container runtimes allow binding to unprivileged ports as non-root. (@ptodev)&#xD;&#xA;&#xD;&#xA;- Update to go 1.22.11 (@wildum)&#xD;&#xA;&#xD;&#xA;### Installation&#xD;&#xA;&#xD;&#xA;Note that Grafana Agent has been deprecated and is in Long-Term Support (LTS) through October 31, 2025. Grafana Agent will reach an End-of-Life (EOL) on November 1, 2025. Read more about why we recommend migrating to [Grafana Alloy](https://grafana.com/blog/2024/04/09/grafana-alloy-opentelemetry-collector-with-prometheus-pipelines/).&#xD;&#xA;&#xD;&#xA;Refer to our installation guides for how to install the variants of Grafana Agent:&#xD;&#xA;&#xD;&#xA;* [Install static mode](https://grafana.com/docs/agent/v0.44/static/set-up/install/)&#xD;&#xA;* [Install the static mode Kubernetes operator](https://grafana.com/docs/agent/v0.44/operator/helm-getting-started/)&#xD;&#xA;* [Install flow mode](https://grafana.com/docs/agent/v0.44/flow/setup/install/)</pre>
            </details>
        </details>
        <details id="ab0ee30df2545cedb3139e6e8ff673a28e83a5be18809abc7c541d44cf4468d0">
            <summary>Bump Operator module version</summary>
            <p>changes detected:&#xA;&#x9;path &#34;locals.version&#34; updated from &#34;0.43.4&#34; to &#34;0.44.2&#34; in file &#34;locals.tf&#34;</p>
            <details>
                <summary>v0.44.2</summary>
                <pre>&#xA;Release published on the 2025-01-29 17:15:37 +0000 UTC at the url https://github.com/grafana/agent/releases/tag/v0.44.2&#xA;&#xA;This is release `v0.44.2` of Grafana Agent.&#xD;&#xA;&#xD;&#xA;### Upgrading&#xD;&#xA;&#xD;&#xA;Read the relevant upgrade guides for specific instructions on upgrading from older versions:&#xD;&#xA;&#xD;&#xA;* [Static mode upgrade guide](https://grafana.com/docs/agent/v0.44/static/upgrade-guide/)&#xD;&#xA;* [Static mode Kubernetes operator upgrade guide](https://grafana.com/docs/agent/v0.44/operator/upgrade-guide/)&#xD;&#xA;* [Flow mode upgrade guide](https://grafana.com/docs/agent/v0.44/flow/upgrade-guide/)&#xD;&#xA;&#xD;&#xA;### Changes:&#xD;&#xA;&#xD;&#xA;#### Bugfixes&#xD;&#xA;&#xD;&#xA;- `loki.source.podlogs`: Fixed a bug which prevented clustering from working and caused duplicate logs to be sent.&#xD;&#xA;  The bug only happened when no `selector` or `namespace_selector` blocks were specified in the Agent configuration. (@ptodev)&#xD;&#xA;&#xD;&#xA;- `pyroscope.scrape` no longer tries to scrape endpoints which are not active targets anymore. (@wildum @mattdurham @dehaansa @ptodev)&#xD;&#xA;&#xD;&#xA;#### Enhancements&#xD;&#xA;&#xD;&#xA;- Upgrade `github.com/goccy/go-json` to v0.10.4, which reduces the memory consumption of an Agent instance by 20MB.&#xD;&#xA;  If Agent is running certain otelcol components, this reduction will not apply. (@ptodev)&#xD;&#xA;  &#xD;&#xA;#### Other changes&#xD;&#xA;&#xD;&#xA;- Remove setcap for `cap_net_bind_service` to allow Agent to run in restricted environments.&#xD;&#xA;  Modern container runtimes allow binding to unprivileged ports as non-root. (@ptodev)&#xD;&#xA;&#xD;&#xA;- Update to go 1.22.11 (@wildum)&#xD;&#xA;&#xD;&#xA;### Installation&#xD;&#xA;&#xD;&#xA;Note that Grafana Agent has been deprecated and is in Long-Term Support (LTS) through October 31, 2025. Grafana Agent will reach an End-of-Life (EOL) on November 1, 2025. Read more about why we recommend migrating to [Grafana Alloy](https://grafana.com/blog/2024/04/09/grafana-alloy-opentelemetry-collector-with-prometheus-pipelines/).&#xD;&#xA;&#xD;&#xA;Refer to our installation guides for how to install the variants of Grafana Agent:&#xD;&#xA;&#xD;&#xA;* [Install static mode](https://grafana.com/docs/agent/v0.44/static/set-up/install/)&#xD;&#xA;* [Install the static mode Kubernetes operator](https://grafana.com/docs/agent/v0.44/operator/helm-getting-started/)&#xD;&#xA;* [Install flow mode](https://grafana.com/docs/agent/v0.44/flow/setup/install/)</pre>
            </details>
        </details>
        <details id="7a7f09de08e3dc01c5bbf90657ecc83d5c2da9f5791f1ebe84132b95422878dc">
            <summary>run kubectl when chart changed</summary>
            <p>ran shell command &#34;rm -rf grafana/charts ksm/charts &amp;&amp; kubectl kustomize . -o grafana-agent.yaml --enable-helm&#34;</p>
        </details>
        <a href="https://github.com/opzkit/terraform-aws-k8s-addons-grafana-agent-operator/actions/runs/13043527983">GitHub Action workflow link</a>
    </action>
</Actions>

---

<table>
  <tr>
    <td width="77">
      <img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="50" height="50">
    </td>
    <td>
      <p>
        Created automatically by <a href="https://www.updatecli.io/">Updatecli</a>
      </p>
      <details><summary>Options:</summary>
        <br />
        <p>Most of Updatecli configuration is done via <a href="https://www.updatecli.io/docs/prologue/quick-start/">its manifest(s)</a>.</p>
        <ul>
          <li>If you close this pull request, Updatecli will automatically reopen it, the next time it runs.</li>
          <li>If you close this pull request and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
        </ul>
        <p>
          Feel free to report any issues at <a href="https://github.com/updatecli/updatecli/issues">github.com/updatecli/updatecli</a>.<br />
          If you find this tool useful, do not hesitate to star <a href="https://github.com/updatecli/updatecli/stargazers">our GitHub repository</a> as a sign of appreciation, and/or to tell us directly on our <a href="https://matrix.to/#/#Updatecli_community:gitter.im">chat</a>!
        </p>
      </details>
    </td>
  </tr>
</table>

