### PR TITLE
docs: mark module as deprecated and suggest migration path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # terraform-aws-k8s-addons-grafana-agent-operator
 
+Deprecated! Migrate to Grafana Alloy using [K8S-monitoring](https://github.com/opzkit/terraform-aws-k8s-addons-grafana-k8s-monitoring)
+
 A terraform module which provides the [custom addon](https://kops.sigs.k8s.io/addons/#custom-addons)
 for [grafana-agent-operator](https://grafana.com/docs/agent/latest/operator/) to be used together
 with [opzkit/k8s/aws](https://registry.terraform.io/modules/opzkit/k8s/aws/latest).


### PR DESCRIPTION
Add a deprecation notice to the README.md file, advising users to migrate 
to Grafana Alloy via the K8S-monitoring repository. This change clarifies 
the current status of the module and guides users towards an updated 
solution.