### PR TITLE
chore: remove pull request trigger for updatecli workflow

### DIFF
--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -5,10 +5,6 @@ on:
   # Trigger Updatecli if a new commit land on the main branch
   push:
     branches: [ main ]
-  # Trigger Updatecli if a pullrequest is open targeting the main branch.
-  # This is useful to test Updatecli manifest change
-  pull_request:
-    branches: [ main ]
   # Manually trigger Updatecli via GitHub UI
   workflow_dispatch:
   # Trigger Updatecli once day by a cronjob


### PR DESCRIPTION
Remove the pull request trigger from the Updatecli GitHub Actions
workflow. This change simplifies the workflow by ensuring that the
Updatecli process only runs on pushes to the main branch and on manual
triggers, streamlining the update process.